### PR TITLE
[ALF-1681] Adding message field to help reproduce Datadog Logs issue

### DIFF
--- a/data/success/driver-found.json
+++ b/data/success/driver-found.json
@@ -1,4002 +1,5502 @@
 [
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jimenez Gibson",
         "company": "Furnafix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Edwina Page",
         "company": "Geekosis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mullins Joseph",
         "company": "Bugsall"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Casey Velazquez",
         "company": "Supremia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Penelope Cervantes",
         "company": "Geekwagon"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tommie Willis",
         "company": "Xurban"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lessie Green",
         "company": "Zensor"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Brigitte Martinez",
         "company": "Satiance"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hansen Rojas",
         "company": "Venoflex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Anita Lynn",
         "company": "Zogak"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rosales Vargas",
         "company": "Puria"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stokes Carrillo",
         "company": "Geeketron"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rodriguez Porter",
         "company": "Gology"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Margery Roberson",
         "company": "Ludak"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Potts Rivas",
         "company": "Nikuda"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Cooley Webb",
         "company": "Roughies"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Patton Carson",
         "company": "Earthplex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wise Morris",
         "company": "Quilk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tamara Vega",
         "company": "Autograte"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kent Mccormick",
         "company": "Oatfarm"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ilene Harper",
         "company": "Undertap"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Munoz Bell",
         "company": "Geoform"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wong Santos",
         "company": "Datacator"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ethel Fulton",
         "company": "Vicon"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kathleen Briggs",
         "company": "Chorizon"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hendrix Farley",
         "company": "Unq"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Betsy Ray",
         "company": "Earthmark"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Medina Holden",
         "company": "Exoteric"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Margie Montgomery",
         "company": "Boink"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Robbins Owen",
         "company": "Magnina"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carol Peters",
         "company": "Xiix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Christi Mercer",
         "company": "Kinetica"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Katrina White",
         "company": "Scentric"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sadie Ayala",
         "company": "Bluplanet"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Juana Finch",
         "company": "Quizmo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Susan Castro",
         "company": "Signidyne"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sloan Mccarty",
         "company": "Geologix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Allison Ratliff",
         "company": "Exospace"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Middleton Durham",
         "company": "Opticom"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stevenson Cardenas",
         "company": "Sentia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Yolanda Carr",
         "company": "Powernet"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hunt Holder",
         "company": "Codax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dillard Boyd",
         "company": "Katakana"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Shannon Wilcox",
         "company": "Tribalog"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Henson Whitaker",
         "company": "Photobin"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wall Barrett",
         "company": "Ezentia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Joni Everett",
         "company": "Housedown"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ellison Knowles",
         "company": "Ceprene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Fitzpatrick Carver",
         "company": "Mazuda"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Eleanor Snow",
         "company": "Deepends"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Farmer Landry",
         "company": "Digial"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kenya Christian",
         "company": "Shadease"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Eugenia Chambers",
         "company": "Ramjob"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Durham Drake",
         "company": "Automon"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tami Freeman",
         "company": "Comtrek"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kris Johns",
         "company": "Gracker"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Valarie Mccullough",
         "company": "Ovation"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Michael Hoover",
         "company": "Fitcore"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rich Vinson",
         "company": "Acrodance"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Claudia Macdonald",
         "company": "Comvene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Slater Wolfe",
         "company": "Lotron"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kathie Roman",
         "company": "Comcur"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stout Harris",
         "company": "Electonic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Powell Hunt",
         "company": "Aquazure"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Koch Pena",
         "company": "Krag"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jenkins Wolf",
         "company": "Recritube"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bridget Gamble",
         "company": "Songbird"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Erin Nolan",
         "company": "Pawnagra"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jeanette Allison",
         "company": "Talkola"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Le Baxter",
         "company": "Ecstasia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rivera Mckenzie",
         "company": "Helixo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kirkland Finley",
         "company": "Digitalus"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carmen Morrow",
         "company": "Everest"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mattie Irwin",
         "company": "Waab"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Therese Wells",
         "company": "Sureplex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Melanie Bishop",
         "company": "Isosure"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Catalina Hall",
         "company": "Bolax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mcfadden Molina",
         "company": "Datagen"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Velazquez Dyer",
         "company": "Volax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Barnett Decker",
         "company": "Andershun"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Isabelle Hardy",
         "company": "Ersum"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Osborne Acosta",
         "company": "Polarium"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Juliet Vaughan",
         "company": "Adornica"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Imelda Brennan",
         "company": "Netbook"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Karyn Park",
         "company": "Nebulean"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Crawford Hess",
         "company": "Shepard"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bonnie Jarvis",
         "company": "Netropic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Randolph Fowler",
         "company": "Entogrok"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Snider Slater",
         "company": "Zoxy"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hatfield Stafford",
         "company": "Glasstep"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carpenter Curtis",
         "company": "Frolix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sybil Benton",
         "company": "Comfirm"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Laverne Salas",
         "company": "Genesynk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carole Potter",
         "company": "Cognicode"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Floyd Ochoa",
         "company": "Genmy"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tisha Cooper",
         "company": "Proxsoft"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Inez Griffin",
         "company": "Toyletry"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Edna Mcgee",
         "company": "Krog"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mann Chavez",
         "company": "Parleynet"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Benton Greene",
         "company": "Vantage"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mitchell Frank",
         "company": "Quarex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wooten Shelton",
         "company": "Straloy"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hurst Lambert",
         "company": "Lunchpod"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Diana Clark",
         "company": "Realysis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Nanette Bray",
         "company": "Gorganic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bullock Ruiz",
         "company": "Quadeebo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Waller Mcdonald",
         "company": "Zillar"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Christian Valenzuela",
         "company": "Wrapture"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mejia Hodges",
         "company": "Securia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hammond Cotton",
         "company": "Furnitech"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Coffey Hood",
         "company": "Homelux"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ratliff Callahan",
         "company": "Tellifly"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Claire Pierce",
         "company": "Singavera"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Calhoun Stephenson",
         "company": "Exposa"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dorsey Odom",
         "company": "Xanide"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Georgina Buckner",
         "company": "Isotronic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marla Guerra",
         "company": "Paragonia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lee Bradley",
         "company": "Bostonic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Parks Duke",
         "company": "Asimiline"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sofia Bush",
         "company": "Sunclipse"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Noreen Kramer",
         "company": "Portalis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sonja Blankenship",
         "company": "Schoolio"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mary Mejia",
         "company": "Zentry"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Snyder Black",
         "company": "Megall"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Suzette Savage",
         "company": "Fibrodyne"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Leta Norton",
         "company": "Stucco"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Iris Thomas",
         "company": "Futurize"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ebony Benjamin",
         "company": "Teraprene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jessica Richard",
         "company": "Enomen"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sheppard Stark",
         "company": "Cujo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mcgowan Avery",
         "company": "Exostream"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Molly Livingston",
         "company": "Rodemco"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Valenzuela Marquez",
         "company": "Geekfarm"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Solomon Eaton",
         "company": "Irack"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Owens Garner",
         "company": "Elemantra"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hurley Pratt",
         "company": "Affluex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Beasley Ferguson",
         "company": "Telepark"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Campos Alvarado",
         "company": "Zentime"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mandy Nicholson",
         "company": "Junipoor"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hood Lott",
         "company": "Acumentor"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Helena Howe",
         "company": "Pushcart"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sims Simon",
         "company": "Ronelon"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Gutierrez Kane",
         "company": "Emoltra"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Katelyn Baldwin",
         "company": "Firewax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Flora Guerrero",
         "company": "Voratak"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dominique Vazquez",
         "company": "Emtrac"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Fisher Mcintosh",
         "company": "Ovolo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hubbard Mcconnell",
         "company": "Comvoy"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rosemary Mcintyre",
         "company": "Intergeek"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Newton Velasquez",
         "company": "Blurrybus"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mallory Romero",
         "company": "Pyramis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Velma Poole",
         "company": "Koogle"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Galloway Herman",
         "company": "Otherside"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Shelby Sweeney",
         "company": "Portica"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ware Osborne",
         "company": "Dancity"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Graves Santiago",
         "company": "Medmex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bond Mendez",
         "company": "Zepitope"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marks Kline",
         "company": "Canopoly"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Caldwell Williamson",
         "company": "Extragene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stanton Anderson",
         "company": "Applica"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jackie Davis",
         "company": "Maximind"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Turner Ellis",
         "company": "Orbiflex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hayden Justice",
         "company": "Minga"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wells Church",
         "company": "Playce"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Larsen Powers",
         "company": "Geekol"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kerri Hobbs",
         "company": "Rodeomad"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wolf Holland",
         "company": "Zentia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Joann Morrison",
         "company": "Overplex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Nellie Fuller",
         "company": "Yurture"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mosley Delgado",
         "company": "Buzzmaker"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hess Cohen",
         "company": "Updat"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Juliette Spears",
         "company": "Solgan"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Nell Wall",
         "company": "Cemention"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Barker Stanton",
         "company": "Architax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hill Mcdaniel",
         "company": "Turnling"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Juanita Hickman",
         "company": "Brainclip"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Luisa Oliver",
         "company": "Exoplode"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wanda Harmon",
         "company": "Zaggle"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Silvia Fleming",
         "company": "Plasmosis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ursula Howell",
         "company": "Egypto"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Petersen Mcfadden",
         "company": "Circum"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lesa Mcbride",
         "company": "Anivet"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carey Knox",
         "company": "Koffee"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Chaney Barron",
         "company": "Isoternia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Horn Glenn",
         "company": "Entropix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Imogene David",
         "company": "Artworlds"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rhoda Parrish",
         "company": "Bezal"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Chapman Wilkinson",
         "company": "Snorus"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Cecile Robinson",
         "company": "Providco"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Haynes Clemons",
         "company": "Pathways"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Pearlie Davenport",
         "company": "Speedbolt"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Boone Sanford",
         "company": "Matrixity"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bonita Luna",
         "company": "Quailcom"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Davenport Morse",
         "company": "Sustenza"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stone Ramos",
         "company": "Exoswitch"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Holder Hyde",
         "company": "Xyqag"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bean Cameron",
         "company": "Manglo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Miranda Underwood",
         "company": "Tropoli"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Melton Wood",
         "company": "Balooba"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Angie Pollard",
         "company": "Snowpoke"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Teri Mckay",
         "company": "Qnekt"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Foreman Dillon",
         "company": "Mantro"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Antoinette Reeves",
         "company": "Panzent"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Donna Witt",
         "company": "Exerta"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Krystal Stone",
         "company": "Tingles"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kirsten Meyer",
         "company": "Neteria"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kidd Becker",
         "company": "Comveyor"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dale Sexton",
         "company": "Futuris"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lynn Delaney",
         "company": "Bluegrain"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lydia Ferrell",
         "company": "Hydrocom"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rivas Villarreal",
         "company": "Isbol"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tamika Marshall",
         "company": "Cinaster"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Guadalupe Daniels",
         "company": "Geekola"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ana Mckinney",
         "company": "Biolive"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Moses Barker",
         "company": "Zipak"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mona Morin",
         "company": "Animalia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Clarissa Quinn",
         "company": "Anarco"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Parker Norris",
         "company": "Exotechno"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lacey Cantu",
         "company": "Comtrail"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Justine Boone",
         "company": "Protodyne"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mueller Hester",
         "company": "Cuizine"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Vincent Beasley",
         "company": "Atomica"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Elinor Lester",
         "company": "Zentility"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mcmahon Bowers",
         "company": "Flotonic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lancaster Morton",
         "company": "Konnect"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Edwards Sargent",
         "company": "Interfind"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Socorro Skinner",
         "company": "Enersol"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Verna Mueller",
         "company": "Rocklogic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Cook Newton",
         "company": "Kidgrease"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Terrell Burch",
         "company": "Maroptic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sullivan Hampton",
         "company": "Idetica"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Harvey King",
         "company": "Rotodyne"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Alexandria Wilson",
         "company": "Sonique"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Montgomery Downs",
         "company": "Poochies"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Vance Sellers",
         "company": "Daycore"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hartman Stout",
         "company": "Kaggle"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dyer Fuentes",
         "company": "Centrexin"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Effie Hooper",
         "company": "Digigene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bass Gilbert",
         "company": "Nurplex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Britt Weiss",
         "company": "Elpro"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marquita Mays",
         "company": "Zenco"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dona Huber",
         "company": "Liquicom"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Pruitt Gibbs",
         "company": "Vitricomp"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hart Faulkner",
         "company": "Marqet"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bettye Lamb",
         "company": "Enervate"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lillian Suarez",
         "company": "Techade"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Boyle Oneal",
         "company": "Digigen"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Veronica Pittman",
         "company": "Extremo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Walton Dickson",
         "company": "Exosis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Clarke Fry",
         "company": "Neurocell"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Yvonne Wise",
         "company": "Portico"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Gay Mcpherson",
         "company": "Eternis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Fran Perkins",
         "company": "Maineland"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Aurora Reid",
         "company": "Barkarama"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sears Melendez",
         "company": "Pharmex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Vang Swanson",
         "company": "Quility"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Witt Wooten",
         "company": "Imaginart"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Allie Bean",
         "company": "Ziore"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Barr Holloway",
         "company": "Comtours"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Huber Shaffer",
         "company": "Kongle"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lucy Lawrence",
         "company": "Tetratrex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Blair Burgess",
         "company": "Zillan"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tiffany Moss",
         "company": "Marketoid"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Odom Todd",
         "company": "Digique"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Norman Ware",
         "company": "Skinserve"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rita Odonnell",
         "company": "Perkle"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ray Conway",
         "company": "Turnabout"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dionne Small",
         "company": "Zappix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ferrell Boyer",
         "company": "Optique"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lina Middleton",
         "company": "Micronaut"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hughes Hubbard",
         "company": "Applidec"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Delacruz Dudley",
         "company": "Primordia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Knapp Mcclure",
         "company": "Centice"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Louise Wheeler",
         "company": "Macronaut"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Perkins Gross",
         "company": "Zaphire"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Whitaker Haynes",
         "company": "Bytrex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Fitzgerald Thompson",
         "company": "Mitroc"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Pacheco Mcleod",
         "company": "Senmao"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Katie Dalton",
         "company": "Inquala"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marie Ball",
         "company": "Petigems"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lindsey Sykes",
         "company": "Uneeq"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ashley Lara",
         "company": "Techmania"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Barrett Cochran",
         "company": "Medicroix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Haley Sparks",
         "company": "Deminimum"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Caitlin Higgins",
         "company": "Peticular"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Elsie Mills",
         "company": "Bitendrex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stevens Byers",
         "company": "Uberlux"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Maryellen Hammond",
         "company": "Retrotex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Salas Mcdowell",
         "company": "Quarmony"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Latisha Jacobson",
         "company": "Xumonk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Holland Richmond",
         "company": "Candecor"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Deena Frazier",
         "company": "Telpod"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Clements Parks",
         "company": "Assistia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Obrien Cortez",
         "company": "Strozen"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Burks Burks",
         "company": "Anocha"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rogers Travis",
         "company": "Izzby"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mcintyre Hinton",
         "company": "Exozent"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marshall Maxwell",
         "company": "Ecolight"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Willis Weber",
         "company": "Omnigog"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Paul Rios",
         "company": "Endipine"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Pittman Zamora",
         "company": "Xsports"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lynch Robles",
         "company": "Letpro"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Walters Alexander",
         "company": "Orbalix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Johnson Montoya",
         "company": "Magnafone"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hooper Lancaster",
         "company": "Corepan"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Melisa Hatfield",
         "company": "Gadtron"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Estella Padilla",
         "company": "Genmex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Katina Palmer",
         "company": "Tetak"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Campbell Benson",
         "company": "Quordate"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Freida Guthrie",
         "company": "Imant"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bridgett Colon",
         "company": "Blanet"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hollie Hays",
         "company": "Yogasm"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bowers Nguyen",
         "company": "Grok"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Susana Price",
         "company": "Comvex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rodriquez Howard",
         "company": "Portaline"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Crosby Foley",
         "company": "Kiggle"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sandy Cantrell",
         "company": "Cogentry"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Parrish Klein",
         "company": "Quintity"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Evans Nelson",
         "company": "Ultrasure"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mendez Arnold",
         "company": "Talendula"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ellen Stuart",
         "company": "Squish"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ann Ward",
         "company": "Spherix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Selena Cummings",
         "company": "Songlines"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Velasquez Jordan",
         "company": "Medalert"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jackson Lynch",
         "company": "Spacewax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Brennan Pacheco",
         "company": "Microluxe"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stella Bass",
         "company": "Insuresys"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "James Holmes",
         "company": "Cowtown"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Townsend Matthews",
         "company": "Ewaves"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ruby Reilly",
         "company": "Shopabout"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Twila Yang",
         "company": "Rugstars"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Aguilar Bradshaw",
         "company": "Tourmania"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Butler Cole",
         "company": "Visualix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lloyd Vasquez",
         "company": "Intradisk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tracy Watts",
         "company": "Tasmania"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Natalia Cleveland",
         "company": "Xylar"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Susanne Whitney",
         "company": "Miracula"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Whitney Andrews",
         "company": "Lunchpad"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wood Blevins",
         "company": "Comstruct"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Francesca Petersen",
         "company": "Olucore"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marianne Sawyer",
         "company": "Apexia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Adams Gordon",
         "company": "Ecraze"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Pope Coffey",
         "company": "Viocular"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Amy Dawson",
         "company": "Corporana"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Heath Gates",
         "company": "Cormoran"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marylou Beard",
         "company": "Slumberia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Gibson Duffy",
         "company": "Splinx"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "York Lowe",
         "company": "Amril"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Gardner Riley",
         "company": "Uncorp"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Yesenia Collins",
         "company": "Daido"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Underwood Castillo",
         "company": "Snips"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Graham Dominguez",
         "company": "Comdom"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Solis Franks",
         "company": "Ontality"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Guthrie Cobb",
         "company": "Bleendot"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Violet Chan",
         "company": "Orbixtar"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Trina Hayes",
         "company": "Isopop"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Fry Roberts",
         "company": "Isologix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kellie Mccall",
         "company": "Bovis"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Cohen Hewitt",
         "company": "Trollery"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Norris Jones",
         "company": "Nexgene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Williamson Duncan",
         "company": "Moreganic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Cleveland Pope",
         "company": "Codact"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Glover Olson",
         "company": "Remotion"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lindsay Hendrix",
         "company": "Zolavo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Acosta Terrell",
         "company": "Nitracyr"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tucker Carroll",
         "company": "Zilidium"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Suzanne Dennis",
         "company": "Ziggles"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sue Craft",
         "company": "Centregy"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ford Bird",
         "company": "Zerbina"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Deann Peck",
         "company": "Ezent"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Fanny Collier",
         "company": "Zytrax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Christina Johnston",
         "company": "Neptide"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lorrie Fisher",
         "company": "Equitox"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Morse Wilkerson",
         "company": "Enerforce"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Malinda Estrada",
         "company": "Jetsilk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carrie Foster",
         "company": "Evidends"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Doyle Garrett",
         "company": "Kyagoro"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sweeney Dodson",
         "company": "Isologics"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jewel Frederick",
         "company": "Omatom"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Richardson Garrison",
         "company": "Polarax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Waters Mccarthy",
         "company": "Permadyne"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Henrietta Dotson",
         "company": "Geekular"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Roberson Farrell",
         "company": "Hinway"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wolfe Obrien",
         "company": "Zanity"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marissa Newman",
         "company": "Isodrive"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Finley Winters",
         "company": "Viagrand"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Pamela Hunter",
         "company": "Waterbaby"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Elba Patel",
         "company": "Utarian"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Everett Moses",
         "company": "Opportech"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Vickie Case",
         "company": "Goko"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Vicki Gilmore",
         "company": "Fleetmix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Eaton Delacruz",
         "company": "Dentrex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Shelly Hughes",
         "company": "Verbus"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Elisabeth Bernard",
         "company": "Sensate"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Beatrice Nichols",
         "company": "Tsunamia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Yvette Gilliam",
         "company": "Kiosk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Deanne Phelps",
         "company": "Duflex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mara Lawson",
         "company": "Enersave"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carly Chaney",
         "company": "Pheast"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stewart Mcneil",
         "company": "Sportan"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Margarita Ortiz",
         "company": "Kengen"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rosario Webster",
         "company": "Malathion"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Howell Cote",
         "company": "Dogtown"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jodie Elliott",
         "company": "Orbaxter"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Macias Nielsen",
         "company": "Lyria"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ingrid Bolton",
         "company": "Ginkogene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Staci Phillips",
         "company": "Boilicon"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Leonor Roach",
         "company": "Genmom"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Vera Mack",
         "company": "Podunk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Josefa Horton",
         "company": "Ecosys"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jerri Tucker",
         "company": "Illumity"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Stark Booth",
         "company": "Utara"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Morton Cain",
         "company": "Keeg"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hester Ryan",
         "company": "Velos"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Newman Stanley",
         "company": "Olympix"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carmela Floyd",
         "company": "Kidstock"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Joy Schneider",
         "company": "Pearlesex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bridgette Fischer",
         "company": "Kneedles"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jill Griffith",
         "company": "Roboid"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jordan Paul",
         "company": "Exospeed"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Debora Fitzpatrick",
         "company": "Geofarm"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Katherine Graham",
         "company": "Aquamate"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Monique Bowman",
         "company": "Frenex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kim Townsend",
         "company": "Collaire"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kemp Flynn",
         "company": "Comtour"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Harrell Goodwin",
         "company": "Navir"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bennett Lee",
         "company": "Bulljuice"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Fern Cannon",
         "company": "Kegular"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Louisa Head",
         "company": "Datagene"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Marisol Mcguire",
         "company": "Dreamia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Moreno Holman",
         "company": "Uplinx"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Gentry Berg",
         "company": "Exiand"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Webb Maynard",
         "company": "Ozean"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Murphy Mullen",
         "company": "Slax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Key Boyle",
         "company": "Magneato"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jami Whitley",
         "company": "Geekology"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Alston Mitchell",
         "company": "Stralum"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Eunice Emerson",
         "company": "Mixers"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lynn Clayton",
         "company": "Slambda"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Christy Brewer",
         "company": "Pulze"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Olga Adkins",
         "company": "Comtract"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sweet Summers",
         "company": "Kangle"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lou Burton",
         "company": "Premiant"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Peggy Snyder",
         "company": "Comtrak"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lori Daugherty",
         "company": "Ecrater"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rocha Hoffman",
         "company": "Kog"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hinton Puckett",
         "company": "Oceanica"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Jensen Malone",
         "company": "Locazone"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Howard Wynn",
         "company": "Andryx"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Camille Mann",
         "company": "Eplosion"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Frye Burris",
         "company": "Zillacon"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ronda Tran",
         "company": "Accruex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sallie Nixon",
         "company": "Accuprint"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Soto Hart",
         "company": "Bullzone"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Carey Short",
         "company": "Baluba"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ferguson Camacho",
         "company": "Apextri"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Mollie Hopper",
         "company": "Hatology"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Nadia Rich",
         "company": "Vetron"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Chase Bailey",
         "company": "Hometown"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Barbra Prince",
         "company": "Quilm"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sherry Miller",
         "company": "Farmage"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bush Jimenez",
         "company": "Springbee"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ava Burnett",
         "company": "Rubadub"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sheree Robbins",
         "company": "Frosnex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Reed Smith",
         "company": "Rockabye"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Holly Caldwell",
         "company": "Fiberox"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Hazel Gregory",
         "company": "Flexigen"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Agnes Rosa",
         "company": "Cytrek"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Love Clay",
         "company": "Aquafire"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Nunez Young",
         "company": "Mobildata"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Kimberly Meadows",
         "company": "Zanymax"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Bishop Carlson",
         "company": "Zilodyne"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Allyson Mclaughlin",
         "company": "Zorromop"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Melissa Guy",
         "company": "Emtrak"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Callie Chapman",
         "company": "Hopeli"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Salazar Dillard",
         "company": "Moltonic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Cassie Pugh",
         "company": "Gink"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Dorothea Christensen",
         "company": "Geostele"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Gail Wallace",
         "company": "Vixo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Noelle Moran",
         "company": "Interloo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Saundra Patrick",
         "company": "Plasmox"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Ada Pruitt",
         "company": "Accel"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Clay Ford",
         "company": "Overfork"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Madelyn Rodriguez",
         "company": "Eargo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Lillie Mcfarland",
         "company": "Handshake"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Oneal Burt",
         "company": "Xeronk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rutledge Ewing",
         "company": "Qiao"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Wade Berger",
         "company": "Optyk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Rosario Booker",
         "company": "Strezzo"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Barrera Hawkins",
         "company": "Essensia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Miriam Horne",
         "company": "Progenex"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Foley Frye",
         "company": "Nixelt"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Francisca Kirby",
         "company": "Maxemia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Herrera Mcmillan",
         "company": "Menbrain"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Sanders Hendricks",
         "company": "Bedder"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Logan Burns",
         "company": "Qimonk"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Chasity Nash",
         "company": "Xplor"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Winnie Soto",
         "company": "Plexia"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Duffy Merritt",
         "company": "Golistic"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     },
     {
       "log_level": "info",
-      "event": "DriverFound",
+      "event": "request_finished",
       "body": {
         "driver_name": "Tyler Brock",
         "company": "Recrisys"
+      },
+      "message": {
+        "event": "DriverFound"
       }
     }
   ]

--- a/data/success/payment-accepted.json
+++ b/data/success/payment-accepted.json
@@ -6,9 +6,7 @@
         "token": "037eafd2-d721-48d8-b52f-4785e8238ca1",
         "price": 85.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -17,9 +15,7 @@
         "token": "b541b2b2-e331-4852-87d8-7987a6780ef4",
         "price": 82.81
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -28,9 +24,7 @@
         "token": "76671516-8d75-4a57-92a5-fbc4abd33b7a",
         "price": 80.94
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -39,9 +33,7 @@
         "token": "66e28edf-3743-4a8d-af60-3e3075e40bff",
         "price": 21.58
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -50,9 +42,7 @@
         "token": "c6b86574-cd5e-404c-8c37-46475d1eae16",
         "price": 63.72
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -61,9 +51,7 @@
         "token": "47b00ab1-0c8b-42ef-bd6d-f1622a083723",
         "price": 14.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -72,9 +60,7 @@
         "token": "f874305e-65f1-4271-b582-ce213ba28723",
         "price": 50.58
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -83,9 +69,7 @@
         "token": "f36d3275-9b27-4955-9741-3a33434a600d",
         "price": 93.36
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -94,9 +78,7 @@
         "token": "65d4eb34-5057-4d72-9808-6f3042ce27ec",
         "price": 55.39
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -105,9 +87,7 @@
         "token": "8bf1d391-799b-4286-9a0c-3a2cd15cd201",
         "price": 91.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -116,9 +96,7 @@
         "token": "300a485f-3658-4edc-af22-1382c17cbdf9",
         "price": 11.42
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -127,9 +105,7 @@
         "token": "ae9d3037-adee-40d2-ac45-b522fedb8982",
         "price": 19.5
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -138,9 +114,7 @@
         "token": "a5e951c7-9524-4662-8e1e-260c64c85325",
         "price": 12.36
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -149,9 +123,7 @@
         "token": "e25a66fd-2a77-440c-96a2-8b6a58e10092",
         "price": 75.2
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -160,9 +132,7 @@
         "token": "90852476-c300-4ef0-95d3-71002cc4ebb3",
         "price": 96.33
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -171,9 +141,7 @@
         "token": "f6b22800-200f-4305-b84b-bfe608a9fb20",
         "price": 96.05
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -182,9 +150,7 @@
         "token": "f0b942c0-5a1f-4c4d-9c20-dcc02e303f89",
         "price": 59.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -193,9 +159,7 @@
         "token": "c9f4b616-ce78-4243-9286-70ebc4844556",
         "price": 40.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -204,9 +168,7 @@
         "token": "5789c051-30f5-4314-9832-8eeb0183f978",
         "price": 83.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -215,9 +177,7 @@
         "token": "cd367e31-e373-497b-b5b7-dd4c20a11f4f",
         "price": 85.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -226,9 +186,7 @@
         "token": "43d410fd-221c-4b5b-9091-327282cf540b",
         "price": 61.5
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -237,9 +195,7 @@
         "token": "221ebd49-654e-4cdf-b3f1-6858ad2dd1ed",
         "price": 47.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -248,9 +204,7 @@
         "token": "8918bf18-1c01-4e33-ac47-c677ce7843e0",
         "price": 75.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -259,9 +213,7 @@
         "token": "f78871f4-ec75-4df4-a7c0-b2b6e5649de4",
         "price": 48.45
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -270,9 +222,7 @@
         "token": "85d0219b-9813-4582-955a-319146ee7fc0",
         "price": 19.73
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -281,9 +231,7 @@
         "token": "45272463-03d5-4a22-8c7b-34d55fedabf6",
         "price": 67.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -292,9 +240,7 @@
         "token": "39364ae6-4a2e-41d8-83d0-98ca650942af",
         "price": 98.83
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -303,9 +249,7 @@
         "token": "9f755d32-8e72-4410-9f75-64b510e7157b",
         "price": 19.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -314,9 +258,7 @@
         "token": "3dca6aa2-35e2-44ad-bb0d-947527a2f58d",
         "price": 44.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -325,9 +267,7 @@
         "token": "40722e82-2975-456e-b4d0-96215e7e8e9d",
         "price": 28.83
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -336,9 +276,7 @@
         "token": "75b2fd13-45d9-4d38-a00a-3333f5bac908",
         "price": 47.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -347,9 +285,7 @@
         "token": "c38347dc-fb09-4e1f-9854-1cac8f4f968f",
         "price": 61.29
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -358,9 +294,7 @@
         "token": "57f99d16-d4f6-4c2a-898d-8ba8634d080c",
         "price": 75.69
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -369,9 +303,7 @@
         "token": "1fca6512-8a16-412d-89e9-8f4670c41e26",
         "price": 37.88
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -380,9 +312,7 @@
         "token": "78b8dc3f-2fb6-4c2a-b382-6e16275f01f3",
         "price": 13.07
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -391,9 +321,7 @@
         "token": "b9bb57af-beb9-4129-b532-c2b04bfe7aa4",
         "price": 40.76
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -402,9 +330,7 @@
         "token": "59df4751-c5ca-465c-826a-a6e488ed484e",
         "price": 84.63
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -413,9 +339,7 @@
         "token": "080977f7-5b08-4575-9b45-ee80adf1f034",
         "price": 66.01
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -424,9 +348,7 @@
         "token": "a6cb4bf5-f7c7-4bcd-9b94-9869020939f3",
         "price": 16.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -435,9 +357,7 @@
         "token": "031b2e75-e7b2-4196-911e-62542824600a",
         "price": 39.07
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -446,9 +366,7 @@
         "token": "d7fe1481-a1c0-4b6d-a13a-ec92010df6f2",
         "price": 31.37
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -457,9 +375,7 @@
         "token": "fb210c21-ff47-44a4-8fa0-3f4e831c1bdb",
         "price": 58.72
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -468,9 +384,7 @@
         "token": "8077e01b-bda4-447a-8ef3-f3a978152656",
         "price": 15.65
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -479,9 +393,7 @@
         "token": "e1bc6c1b-7926-4bc4-9e9a-7ab936b96831",
         "price": 31.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -490,9 +402,7 @@
         "token": "35de2d41-f4bf-4adf-b9a1-ba7a036da2e9",
         "price": 81.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -501,9 +411,7 @@
         "token": "1bb674a8-7885-4e15-90a1-04350695ce5b",
         "price": 88.19
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -512,9 +420,7 @@
         "token": "227acaa7-d92e-4c83-a93d-9fde07614e7b",
         "price": 66.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -523,9 +429,7 @@
         "token": "e9494acb-1b47-47bd-9d13-b17aa38cea9a",
         "price": 58.84
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -534,9 +438,7 @@
         "token": "00f57989-34ae-4124-bcee-e9e1fd7bb32f",
         "price": 44.28
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -545,9 +447,7 @@
         "token": "bab9706d-8d9e-4153-8f2d-ace1c156ff77",
         "price": 29.65
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -556,9 +456,7 @@
         "token": "d91bbc27-c3b9-4959-acf6-301693fa1dff",
         "price": 63.98
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -567,9 +465,7 @@
         "token": "268b2a29-a68c-42e6-8dc5-a7f8780e4396",
         "price": 58.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -578,9 +474,7 @@
         "token": "0bfd8525-df10-40bc-b811-cace89f66b58",
         "price": 83.64
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -589,9 +483,7 @@
         "token": "4dcd3be3-c1cb-49d3-ab9e-77759cb50c2f",
         "price": 24.63
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -600,9 +492,7 @@
         "token": "8b451f5d-1677-4068-a17c-5bbd3a2fe5a2",
         "price": 94.36
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -611,9 +501,7 @@
         "token": "2a5239c9-df75-4c57-98b8-522a53ec82b1",
         "price": 30.57
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -622,9 +510,7 @@
         "token": "10fb7421-3b9d-48da-b253-77810f2cc4b7",
         "price": 13.37
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -633,9 +519,7 @@
         "token": "12bfeba6-3678-4a92-9e31-4b1eedf164ab",
         "price": 86.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -644,9 +528,7 @@
         "token": "a58bb9a4-d8f7-40fa-81ec-6201d1da1789",
         "price": 19.41
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -655,9 +537,7 @@
         "token": "9f8b0926-67c5-483f-939b-3651773edc8c",
         "price": 21.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -666,9 +546,7 @@
         "token": "be56f583-d5cc-48d0-b18b-2a09305a4f0b",
         "price": 74.74
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -677,9 +555,7 @@
         "token": "875598cd-1178-44d8-9906-670f705361d8",
         "price": 31.47
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -688,9 +564,7 @@
         "token": "7a5981fa-c11b-435d-a4da-53077dc405e6",
         "price": 41.02
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -699,9 +573,7 @@
         "token": "54f8484b-f202-4364-9b96-5a6111c26c99",
         "price": 34.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -710,9 +582,7 @@
         "token": "6ce845f0-3534-4619-a04c-73acf020f2ee",
         "price": 45.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -721,9 +591,7 @@
         "token": "94235d34-42f1-416d-b174-91a713b0bbb1",
         "price": 13.28
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -732,9 +600,7 @@
         "token": "cb41735d-b92f-4d03-9d0b-085b20ffff0e",
         "price": 70.11
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -743,9 +609,7 @@
         "token": "3a558f8c-8382-4257-9752-0f60a0c7b54f",
         "price": 51.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -754,9 +618,7 @@
         "token": "04260751-c28a-4340-a512-d754859fde7f",
         "price": 83.88
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -765,9 +627,7 @@
         "token": "abc74ae2-ee7d-4bba-a57a-60f9bacaec1d",
         "price": 34.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -776,9 +636,7 @@
         "token": "fdfe50da-ac7a-4071-acb9-f4c40bd8c346",
         "price": 14.77
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -787,9 +645,7 @@
         "token": "ed7ce93e-46ad-4f46-a208-fa6f526cef12",
         "price": 24.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -798,9 +654,7 @@
         "token": "002f8980-196e-48f9-901a-422e4ffc3bd5",
         "price": 20.13
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -809,9 +663,7 @@
         "token": "c77430ec-0318-4e9a-8990-a1d252e8e44c",
         "price": 92.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -820,9 +672,7 @@
         "token": "a80fe69a-46ed-43c4-9b64-874a1c8410bf",
         "price": 59.38
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -831,9 +681,7 @@
         "token": "b78063e9-9db4-47ea-896f-0f49c11c00bb",
         "price": 28.55
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -842,9 +690,7 @@
         "token": "d1f6745b-bfb4-4ccb-af96-96839ed12bb7",
         "price": 81.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -853,9 +699,7 @@
         "token": "ee4a7af5-aa7b-40b9-85a7-1b9d63c37646",
         "price": 45.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -864,9 +708,7 @@
         "token": "2216c437-97b5-4ae4-bbf7-3b09d0775b49",
         "price": 77.39
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -875,9 +717,7 @@
         "token": "4e30267a-5f49-4b35-bcdf-d8a9fba4a8d0",
         "price": 63.15
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -886,9 +726,7 @@
         "token": "42849e45-9162-4ecf-8144-22acee35b43d",
         "price": 31.91
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -897,9 +735,7 @@
         "token": "d1df9378-0bd1-4c2e-8a2b-9885ade81779",
         "price": 66.05
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -908,9 +744,7 @@
         "token": "4cf09c40-28ba-4a23-98d8-1495edb9b3f8",
         "price": 65.31
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -919,9 +753,7 @@
         "token": "84b60956-1f9d-47ed-b4fc-e26ed932a604",
         "price": 20.79
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -930,9 +762,7 @@
         "token": "e709d376-1412-49aa-99c6-b3a4218eebcf",
         "price": 93.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -941,9 +771,7 @@
         "token": "e2943091-17a1-47e0-96db-e60bffec875b",
         "price": 73.24
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -952,9 +780,7 @@
         "token": "0fd5727b-b757-4ea1-9cc3-dc8dca38679b",
         "price": 83.47
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -963,9 +789,7 @@
         "token": "85112b58-85da-4ba8-b964-6c9ead0a8c9c",
         "price": 39.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -974,9 +798,7 @@
         "token": "da13829d-d40f-4f2d-8e61-c94abaf21bc3",
         "price": 83.7
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -985,9 +807,7 @@
         "token": "ec9f023a-03c3-470f-affc-5309daa7f49a",
         "price": 73.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -996,9 +816,7 @@
         "token": "1c3785f8-62e9-4fc7-8e6b-974a647bd9a3",
         "price": 79.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1007,9 +825,7 @@
         "token": "e35fb860-3703-480b-9523-0a61dd3e5c78",
         "price": 72.44
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1018,9 +834,7 @@
         "token": "778fa965-7492-4fe6-b9c5-b8e3b9ca2800",
         "price": 72.89
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1029,9 +843,7 @@
         "token": "da98845c-7ac3-4d70-ab5e-d29cfa4a05bc",
         "price": 67.1
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1040,9 +852,7 @@
         "token": "b6f2e3a3-332b-4e80-84f1-7de91dd4d099",
         "price": 76.77
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1051,9 +861,7 @@
         "token": "65819012-5f4a-49a7-9a79-936890628d86",
         "price": 34.21
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1062,9 +870,7 @@
         "token": "7e502853-9462-41e5-8597-f2f2ec34b3f8",
         "price": 79.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1073,9 +879,7 @@
         "token": "1a0ae311-7b80-4aae-b479-be9744cba86a",
         "price": 85.15
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1084,9 +888,7 @@
         "token": "6cf73040-7f3e-43fa-b5a4-4569500246ee",
         "price": 52.29
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1095,9 +897,7 @@
         "token": "94d780bc-6dee-41a4-9919-f1d55a33170f",
         "price": 40.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1106,9 +906,7 @@
         "token": "20fb559d-1a8b-4874-be94-df4f86cfcd15",
         "price": 32.81
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1117,9 +915,7 @@
         "token": "99bf7b9d-0325-4375-87de-4015e806fbf0",
         "price": 67.28
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1128,9 +924,7 @@
         "token": "763502f3-de2b-4c02-9ada-c02d572898eb",
         "price": 10.36
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1139,9 +933,7 @@
         "token": "d0cf242d-6f9f-49b1-86cc-95bbb1ca93da",
         "price": 86.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1150,9 +942,7 @@
         "token": "3b1c6d84-70f0-470d-916a-5d0ae8f38129",
         "price": 66.07
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1161,9 +951,7 @@
         "token": "f4b839b0-078c-46a8-a3bc-03847293f4c4",
         "price": 59.06
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1172,9 +960,7 @@
         "token": "64e09a13-81af-4462-8179-caadd4c79873",
         "price": 71.01
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1183,9 +969,7 @@
         "token": "0c7fb03c-73a5-4a3b-9310-da4a4e2ff60c",
         "price": 20.22
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1194,9 +978,7 @@
         "token": "75c41d96-2d70-49d0-81d4-3054b898d227",
         "price": 23.4
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1205,9 +987,7 @@
         "token": "9739995f-b643-41c4-8cc2-bf0a445915d6",
         "price": 74.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1216,9 +996,7 @@
         "token": "3b3e88f0-8201-45ce-8315-4b48f85d69c1",
         "price": 52.62
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1227,9 +1005,7 @@
         "token": "2dd9006d-eac6-4208-b5c5-4ff665002e36",
         "price": 20.46
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1238,9 +1014,7 @@
         "token": "19957d05-ab94-4179-aaf3-15918d780719",
         "price": 91.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1249,9 +1023,7 @@
         "token": "4c41571b-c7b3-462c-a43e-98e43d4c8b93",
         "price": 39.02
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1260,9 +1032,7 @@
         "token": "128534c9-a27e-40d1-8269-1b4ac305400d",
         "price": 56.63
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1271,9 +1041,7 @@
         "token": "59d68d1c-049f-42f8-be0a-37eda211b84e",
         "price": 70.05
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1282,9 +1050,7 @@
         "token": "49b016e0-0e9a-4564-a445-493573820051",
         "price": 84
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1293,9 +1059,7 @@
         "token": "b1e73dfb-de05-473e-9407-572a00e3e9a4",
         "price": 31.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1304,9 +1068,7 @@
         "token": "83759e87-425c-4101-bc4d-6f8dcad47b18",
         "price": 97.11
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1315,9 +1077,7 @@
         "token": "5916860f-1c8e-4f4e-8f9e-5df631bc2397",
         "price": 55.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1326,9 +1086,7 @@
         "token": "6d619931-b460-44ec-bb81-2104021932f7",
         "price": 79.85
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1337,9 +1095,7 @@
         "token": "df86e125-2d84-4150-9540-89dd87fc8fd4",
         "price": 70.05
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1348,9 +1104,7 @@
         "token": "45f5ece7-e941-492a-811f-45b73c1dbf72",
         "price": 52.38
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1359,9 +1113,7 @@
         "token": "febf190d-75df-4ef6-bc45-e5d6103827a6",
         "price": 59.06
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1370,9 +1122,7 @@
         "token": "e37591ba-d960-4075-96ea-01a6ac1a3701",
         "price": 78.69
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1381,9 +1131,7 @@
         "token": "57ee2e72-f8e0-44e4-a018-0bebb6a55a21",
         "price": 48.7
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1392,9 +1140,7 @@
         "token": "a85d5c8b-1969-42e6-8923-ff17d96cf74a",
         "price": 67.1
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1403,9 +1149,7 @@
         "token": "c71105d0-823e-485b-a0f8-8aeaaef375fe",
         "price": 58.89
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1414,9 +1158,7 @@
         "token": "16260140-acfd-48ab-9482-edb13b68de40",
         "price": 79.27
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1425,9 +1167,7 @@
         "token": "22439821-de16-4b24-bb9a-b089e9160ed2",
         "price": 80.16
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1436,9 +1176,7 @@
         "token": "8ebc985f-7ed4-41b7-88d1-3b79cd14be02",
         "price": 89.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1447,9 +1185,7 @@
         "token": "3aadaec3-4ef3-44ca-8616-234d244bbf66",
         "price": 99.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1458,9 +1194,7 @@
         "token": "c82fbe3e-eb6d-45a7-b335-70278b804a96",
         "price": 70.76
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1469,9 +1203,7 @@
         "token": "d116b5ad-4c5f-4f57-942d-f4a69297cc77",
         "price": 44.28
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1480,9 +1212,7 @@
         "token": "c8dd8a9c-70aa-4454-bae3-c8bb8a9bd389",
         "price": 17.3
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1491,9 +1221,7 @@
         "token": "22f0b560-46df-4898-bb7c-10494039855f",
         "price": 10.21
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1502,9 +1230,7 @@
         "token": "b253521f-f873-4ded-8ee9-5e5171672119",
         "price": 25.5
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1513,9 +1239,7 @@
         "token": "296655f9-88ec-4bb7-bd0c-6737c81f0c1a",
         "price": 90.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1524,9 +1248,7 @@
         "token": "93bab2e7-1911-4fe5-97cc-3f2330e0d817",
         "price": 97.99
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1535,9 +1257,7 @@
         "token": "70c381c5-3cb1-4d0a-ac6a-98175eadb166",
         "price": 43.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1546,9 +1266,7 @@
         "token": "46ad78f9-cb49-4a4c-8090-6ca70702aaef",
         "price": 44.71
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1557,9 +1275,7 @@
         "token": "b4143b16-4026-447a-bff8-87d4c7e7479c",
         "price": 66.47
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1568,9 +1284,7 @@
         "token": "d86cf016-e8ee-4130-a2ea-8e887955e5b9",
         "price": 43.38
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1579,9 +1293,7 @@
         "token": "50fc2f9e-e54c-4080-8ccf-ce69238117ae",
         "price": 29.58
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1590,9 +1302,7 @@
         "token": "94b877aa-8dee-46db-bc73-e60676da8fb3",
         "price": 16.34
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1601,9 +1311,7 @@
         "token": "640e4fd6-ab34-432f-a4bc-8f160d1d7849",
         "price": 56.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1612,9 +1320,7 @@
         "token": "df0cff30-3d80-4015-a719-a5685fe20df0",
         "price": 94.11
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1623,9 +1329,7 @@
         "token": "f58421c8-8eaf-4d7a-9114-226e11a8180e",
         "price": 80.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1634,9 +1338,7 @@
         "token": "7756b72d-7b40-4fda-ad7c-19b72bd05918",
         "price": 22.3
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1645,9 +1347,7 @@
         "token": "49e20ff7-fab7-44eb-88cf-d6e26f765f9f",
         "price": 87.12
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1656,9 +1356,7 @@
         "token": "7522a0cd-5abd-446d-89f6-1e9178aec15b",
         "price": 80.06
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1667,9 +1365,7 @@
         "token": "6d9b8e42-fdee-444e-9ddb-e732dd3b5a19",
         "price": 79.73
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1678,9 +1374,7 @@
         "token": "99a4a516-19b1-41bf-b1e3-39d8821e1d15",
         "price": 33.57
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1689,9 +1383,7 @@
         "token": "bf7f40ff-3676-4486-8481-70dae32c9222",
         "price": 61.85
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1700,9 +1392,7 @@
         "token": "8a170ab2-1a39-4ce2-b750-3d28b9790622",
         "price": 46.97
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1711,9 +1401,7 @@
         "token": "c191922a-207c-4881-b7e4-8d9cc1f63e49",
         "price": 93.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1722,9 +1410,7 @@
         "token": "6eb9f21e-e469-4d81-8bd3-2ecf9344b3b4",
         "price": 69.19
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1733,9 +1419,7 @@
         "token": "6b3ec23b-85f2-4cb4-b8ce-61e9113f05fe",
         "price": 47.39
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1744,9 +1428,7 @@
         "token": "e85850a2-4d4f-427e-abf4-0187c8c47b08",
         "price": 28.86
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1755,9 +1437,7 @@
         "token": "51ed347a-7072-4f89-a68d-a87ef1ef0720",
         "price": 54.57
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1766,9 +1446,7 @@
         "token": "f1da1692-38ee-4e00-8da3-4d0bdf099b60",
         "price": 33.91
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1777,9 +1455,7 @@
         "token": "48818101-9fc4-41ff-8142-6f4f9ca5f3e4",
         "price": 15.86
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1788,9 +1464,7 @@
         "token": "1fb43c21-a8d4-4aab-a735-0369cde83920",
         "price": 71.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1799,9 +1473,7 @@
         "token": "b29e4cbb-d0bc-4883-8f71-19dab985c79c",
         "price": 66.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1810,9 +1482,7 @@
         "token": "c692fd5c-c09e-4973-becd-34ef0f0f3674",
         "price": 14.38
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1821,9 +1491,7 @@
         "token": "ef590265-29cf-45c0-9417-7dddeb6a0f59",
         "price": 68.01
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1832,9 +1500,7 @@
         "token": "a3e687e7-63df-4e47-8a6b-93bd81123093",
         "price": 31.22
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1843,9 +1509,7 @@
         "token": "1d5b2560-748f-4de3-8fab-e3a6a769de1a",
         "price": 43.47
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1854,9 +1518,7 @@
         "token": "9a21afff-6fb1-4ff7-8959-d18803827f76",
         "price": 15.87
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1865,9 +1527,7 @@
         "token": "717288aa-4bd3-41ff-bc00-2dba14ac509b",
         "price": 75.4
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1876,9 +1536,7 @@
         "token": "2511e794-9402-40f1-9e58-10c1f33186ed",
         "price": 19.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1887,9 +1545,7 @@
         "token": "52889f94-14db-4c5a-9e21-595af9a0cf39",
         "price": 96.3
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1898,9 +1554,7 @@
         "token": "6a0afcda-29c5-48c5-b283-5c000fec1613",
         "price": 10.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1909,9 +1563,7 @@
         "token": "fd5bd488-042c-4e3f-a03d-be3496bfc5c7",
         "price": 17.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1920,9 +1572,7 @@
         "token": "edebc8a3-bd8b-417b-adf6-ad2d1dfec1ed",
         "price": 81.47
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1931,9 +1581,7 @@
         "token": "fd29d24e-faa3-4bc3-ad24-8b5d1c1a4d54",
         "price": 66.45
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1942,9 +1590,7 @@
         "token": "8a726454-54ce-472a-92ec-a2af6ca0d527",
         "price": 62.16
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1953,9 +1599,7 @@
         "token": "a08ef211-d996-483b-a63d-c8279261ed23",
         "price": 86.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1964,9 +1608,7 @@
         "token": "06d04bea-b522-495d-9b80-a67866dcf241",
         "price": 81.5
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1975,9 +1617,7 @@
         "token": "2324b571-edf4-43ef-815f-1dbdc81fcb5c",
         "price": 82.77
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1986,9 +1626,7 @@
         "token": "1c9f3a7a-2e24-4199-95d9-aeb4cbd50484",
         "price": 79.22
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -1997,9 +1635,7 @@
         "token": "820acbfd-13a8-4043-b16d-3fd18a5d32ed",
         "price": 94.33
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2008,9 +1644,7 @@
         "token": "b6952a9f-9d22-458f-8052-0e9a94b07e0b",
         "price": 31.21
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2019,9 +1653,7 @@
         "token": "d02e8ea8-191a-45b7-9593-a96663cceac7",
         "price": 11.56
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2030,9 +1662,7 @@
         "token": "f187e6f0-62ae-49e3-b273-0f47c25cbffc",
         "price": 53.64
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2041,9 +1671,7 @@
         "token": "53ac9b66-b4dd-4ac6-b07e-fd979d9195bc",
         "price": 75.58
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2052,9 +1680,7 @@
         "token": "38ae3bf5-b7ee-44a8-a0fc-5b5d021c8a79",
         "price": 60.89
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2063,9 +1689,7 @@
         "token": "01e30649-6dfc-4246-bc0b-54d04fea6699",
         "price": 21.45
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2074,9 +1698,7 @@
         "token": "b7449156-2633-4bc6-a846-726e694572fa",
         "price": 81.81
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2085,9 +1707,7 @@
         "token": "ca160e1b-388c-4f91-aa0d-4206d079d937",
         "price": 53.15
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2096,9 +1716,7 @@
         "token": "69ddc5b5-1600-4f79-b048-8cb310347349",
         "price": 92.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2107,9 +1725,7 @@
         "token": "36653add-07b4-4f5a-8cdb-8f6fdb343640",
         "price": 89.24
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2118,9 +1734,7 @@
         "token": "ee9f2e89-0138-46fb-92d4-25230642651f",
         "price": 74.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2129,9 +1743,7 @@
         "token": "314fa286-2cdb-4596-85c5-9b8a497732df",
         "price": 60.46
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2140,9 +1752,7 @@
         "token": "6cd365ee-1bcd-417a-962f-7a02ce8a24cf",
         "price": 15.29
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2151,9 +1761,7 @@
         "token": "e51e4493-b059-4a6e-b386-06eda77e553b",
         "price": 89.47
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2162,9 +1770,7 @@
         "token": "adaea9b0-ce9a-43e5-b671-273335665abb",
         "price": 17.84
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2173,9 +1779,7 @@
         "token": "905c869a-12ca-4a59-928b-cad72424a6be",
         "price": 39.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2184,9 +1788,7 @@
         "token": "e3770c4c-0423-4ebd-9766-5c9b1af8c720",
         "price": 16.35
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2195,9 +1797,7 @@
         "token": "2fab66c0-f574-45d1-81a4-5d3cacc5b586",
         "price": 90.97
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2206,9 +1806,7 @@
         "token": "cde31ff5-d3d9-436b-a975-43d9fe867555",
         "price": 99.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2217,9 +1815,7 @@
         "token": "89fe3b28-1ecc-401a-94f6-f632f25367a9",
         "price": 10.87
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2228,9 +1824,7 @@
         "token": "b5d91dad-8f6c-4813-b50c-dc935a6a7f5f",
         "price": 90.54
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2239,9 +1833,7 @@
         "token": "5492f845-9426-4e4a-ac39-5047be2d1f2f",
         "price": 60.16
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2250,9 +1842,7 @@
         "token": "f591a4ee-53c4-4090-992a-17e3b6001a47",
         "price": 32.63
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2261,9 +1851,7 @@
         "token": "3865cbcc-17d0-4bb7-a517-0b845246ffed",
         "price": 30.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2272,9 +1860,7 @@
         "token": "56c1442d-43c8-4f57-b582-e23cb0a72270",
         "price": 30.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2283,9 +1869,7 @@
         "token": "266f2c91-9e90-4a6f-b258-89a7f6ab4b69",
         "price": 30.98
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2294,9 +1878,7 @@
         "token": "45b84d57-fca4-4f77-bc2e-996258df211c",
         "price": 52.56
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2305,9 +1887,7 @@
         "token": "0af1abaa-44e4-4562-b50d-77fbec330716",
         "price": 54.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2316,9 +1896,7 @@
         "token": "f7b67e75-ec09-4102-866a-1af1b2845141",
         "price": 44.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2327,9 +1905,7 @@
         "token": "b41ef9c0-24d4-4d4e-8dce-22fe7e0fec18",
         "price": 81.79
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2338,9 +1914,7 @@
         "token": "9bd9e4bd-7843-4816-bc77-0b0a8dff1d87",
         "price": 88.56
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2349,9 +1923,7 @@
         "token": "3727c2b8-482f-4a21-b310-e3926493cf37",
         "price": 34.34
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2360,9 +1932,7 @@
         "token": "51407595-63dd-4a8b-a6cd-a93087f7e1ea",
         "price": 50.5
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2371,9 +1941,7 @@
         "token": "3174eb8b-6b77-4995-a9d8-c9cc2d3fb728",
         "price": 18.85
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2382,9 +1950,7 @@
         "token": "f90ec091-fa9b-454d-838e-0c52118e0292",
         "price": 87.89
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2393,9 +1959,7 @@
         "token": "a8c48f6d-d04d-4e35-bc39-dd96eada4f89",
         "price": 73.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2404,9 +1968,7 @@
         "token": "56228c59-0fdf-42b8-92cf-cc1ae20bbcf5",
         "price": 13.07
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2415,9 +1977,7 @@
         "token": "bb241774-3474-45e2-85b4-b755e2122a05",
         "price": 73.44
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2426,9 +1986,7 @@
         "token": "45abe2eb-6410-4314-8c78-e10729f2cf94",
         "price": 44.65
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2437,9 +1995,7 @@
         "token": "a5833851-08be-48f0-9d8f-f6dd8c769d84",
         "price": 99.88
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2448,9 +2004,7 @@
         "token": "b5b079b4-6897-4f6e-8300-1d45e0d6b1b1",
         "price": 97.41
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2459,9 +2013,7 @@
         "token": "b2bfaa0a-9ee0-4f20-928f-ba547c3a5b49",
         "price": 80.78
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2470,9 +2022,7 @@
         "token": "2f3df04b-3ef8-4968-8f54-09736f91fd61",
         "price": 82.98
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2481,9 +2031,7 @@
         "token": "3a12630e-5795-43a5-a13f-e2499e80b188",
         "price": 50.69
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2492,9 +2040,7 @@
         "token": "323e45b8-c707-451f-913c-eb13b01dcdd9",
         "price": 76.67
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2503,9 +2049,7 @@
         "token": "96b5fa90-6e86-4545-96a0-e2bc161f89df",
         "price": 31.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2514,9 +2058,7 @@
         "token": "b5cf7795-4ed5-4e75-99cc-d978e8472431",
         "price": 94.36
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2525,9 +2067,7 @@
         "token": "a62a3be4-cf8c-4c85-9b7b-1c7b3ff06cf5",
         "price": 27.86
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2536,9 +2076,7 @@
         "token": "4e73262b-0dca-4bb9-a375-d117a0d84198",
         "price": 84.44
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2547,9 +2085,7 @@
         "token": "c9b981ee-73d1-4ae5-8ec6-57c47936d6e3",
         "price": 79.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2558,9 +2094,7 @@
         "token": "df2a4dbe-c7f5-49a9-b2aa-fe685a2c7fdc",
         "price": 64.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2569,9 +2103,7 @@
         "token": "4f6030de-407e-42b8-9fa4-ff16e051bfd9",
         "price": 97.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2580,9 +2112,7 @@
         "token": "c05c07d2-5429-44ed-9d67-013850a43588",
         "price": 70.14
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2591,9 +2121,7 @@
         "token": "f2b8e797-5098-404a-aab3-68d12a441e19",
         "price": 65.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2602,9 +2130,7 @@
         "token": "8d4cae77-6608-4629-9332-03d74355d3b6",
         "price": 99.33
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2613,9 +2139,7 @@
         "token": "917b12d1-ac86-47e7-92a9-129f909036a5",
         "price": 84.36
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2624,9 +2148,7 @@
         "token": "94706cd8-c46b-44cb-ac41-e551fd88dbf5",
         "price": 16.53
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2635,9 +2157,7 @@
         "token": "993e2ca3-0042-4425-9495-08aef572633a",
         "price": 98.32
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2646,9 +2166,7 @@
         "token": "40ca13ea-c916-429a-b738-986f3d934fe1",
         "price": 10.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2657,9 +2175,7 @@
         "token": "28ba766e-8ed0-40bc-9000-71de8621fcd2",
         "price": 31.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2668,9 +2184,7 @@
         "token": "8effb1e6-f295-46e7-85ee-fd72ce24cfcf",
         "price": 27.37
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2679,9 +2193,7 @@
         "token": "bd36dd98-746a-4e56-a98d-00e6e9cbbece",
         "price": 24.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2690,9 +2202,7 @@
         "token": "0a2584ea-4998-4e22-9360-1509719eb93d",
         "price": 41.63
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2701,9 +2211,7 @@
         "token": "8bbab90c-a329-409a-b88c-4bd2607a9b27",
         "price": 24.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2712,9 +2220,7 @@
         "token": "79d1cb8f-019d-4d07-a13f-15e7d2ace9aa",
         "price": 58.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2723,9 +2229,7 @@
         "token": "a5921299-2878-4469-9568-c133e0b44713",
         "price": 69.4
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2734,9 +2238,7 @@
         "token": "03d1ea63-92d9-4cfe-a7b8-789a1f67b769",
         "price": 22.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2745,9 +2247,7 @@
         "token": "53aee925-608a-4992-88e4-28e1e7702bc0",
         "price": 29.33
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2756,9 +2256,7 @@
         "token": "339da0f3-8642-49b1-9c55-e0f5c1ebd15e",
         "price": 65.63
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2767,9 +2265,7 @@
         "token": "daa18693-d260-4a04-ba87-57ab52871acd",
         "price": 46.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2778,9 +2274,7 @@
         "token": "4516598c-fabe-4107-9b70-b5ea582bbff2",
         "price": 66.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2789,9 +2283,7 @@
         "token": "5cb8b853-13a8-4e18-91df-950004f6ce3c",
         "price": 63.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2800,9 +2292,7 @@
         "token": "6e4d25f4-2764-4bd4-aada-96e2f32972b5",
         "price": 48.54
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2811,9 +2301,7 @@
         "token": "af428861-b9ac-4c6d-840c-4a20daac487a",
         "price": 33.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2822,9 +2310,7 @@
         "token": "5b599e2a-9be8-4525-94f2-d0b6280d6d5e",
         "price": 82.16
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2833,9 +2319,7 @@
         "token": "00c298f4-364a-443a-a0e5-96fbf894c61e",
         "price": 10.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2844,9 +2328,7 @@
         "token": "df55c0aa-b50f-4dc2-87f6-7884150aeaa5",
         "price": 60.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2855,9 +2337,7 @@
         "token": "d307783f-5d21-479a-8d10-41f4a1416130",
         "price": 36.61
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2866,9 +2346,7 @@
         "token": "41370016-1965-4f2e-b54e-d4c949dc8e1a",
         "price": 59.75
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2877,9 +2355,7 @@
         "token": "d2ad8b02-3d98-4631-9722-83970eaf7ec7",
         "price": 79.83
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2888,9 +2364,7 @@
         "token": "50ba3c81-0fa6-4eb5-9413-10dc677cf948",
         "price": 63.84
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2899,9 +2373,7 @@
         "token": "a8dfb932-b50c-41a4-a17a-e3d1c3e97112",
         "price": 31.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2910,9 +2382,7 @@
         "token": "e4055328-be5d-45d2-b798-040af920157a",
         "price": 40.08
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2921,9 +2391,7 @@
         "token": "043ecb14-763e-4dca-9f06-67126bd3cd81",
         "price": 90.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2932,9 +2400,7 @@
         "token": "bed88942-6685-42fe-ac50-bfe3fd156669",
         "price": 41.17
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2943,9 +2409,7 @@
         "token": "aac95d63-93a5-472a-bb65-af9e8791d70c",
         "price": 52.56
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2954,9 +2418,7 @@
         "token": "2256ad1a-d7d4-42cf-b419-54a173caa71e",
         "price": 95.06
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2965,9 +2427,7 @@
         "token": "68022bb6-e6f4-43b7-afa0-a9b484d38735",
         "price": 91.28
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2976,9 +2436,7 @@
         "token": "4d4b3c37-33b8-470f-b550-a832d0a309be",
         "price": 54.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2987,9 +2445,7 @@
         "token": "d1d13b6c-d338-4d2f-84d1-f5ee9d0b55cc",
         "price": 22.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -2998,9 +2454,7 @@
         "token": "05fa7bc6-b530-4d0d-a9bc-ac7d2d3f7e2b",
         "price": 59.14
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3009,9 +2463,7 @@
         "token": "cc77a3da-2516-41f7-8f4f-28062a71ed3a",
         "price": 84.34
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3020,9 +2472,7 @@
         "token": "549aaf14-57cf-4cd9-8fe4-63c9527ce9b7",
         "price": 11.71
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3031,9 +2481,7 @@
         "token": "6b61a326-eb4a-4a88-badc-3eeef6fc98db",
         "price": 60.59
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3042,9 +2490,7 @@
         "token": "ff90b6aa-f67b-4809-9c25-c0603477328b",
         "price": 10.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3053,9 +2499,7 @@
         "token": "b060c27d-d3b7-45d4-95bd-8b16a65fd213",
         "price": 15.19
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3064,9 +2508,7 @@
         "token": "ba660730-ca85-4863-bb8e-5ce7cbeb1d1b",
         "price": 86.01
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3075,9 +2517,7 @@
         "token": "18e860ed-bd6b-4a5e-bfc7-368842e61dba",
         "price": 48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3086,9 +2526,7 @@
         "token": "9c48d586-7eb1-45fc-a9d2-60164685c900",
         "price": 83.24
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3097,9 +2535,7 @@
         "token": "c2eb7aac-0d0c-4ddb-a766-20bf3229505d",
         "price": 72.14
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3108,9 +2544,7 @@
         "token": "19503237-da3b-492f-a275-ad2c0911961e",
         "price": 52.88
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3119,9 +2553,7 @@
         "token": "61ce4458-3615-4f38-a5ce-ed425f8931ba",
         "price": 20.41
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3130,9 +2562,7 @@
         "token": "e3da5bf0-81c5-4d6a-a164-74a15c77cfcb",
         "price": 24.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3141,9 +2571,7 @@
         "token": "e72fad4e-e09b-41f6-834c-0b1f85d2ff8d",
         "price": 42.84
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3152,9 +2580,7 @@
         "token": "35c2ccc6-f542-41f4-8e08-0d7c07f6daec",
         "price": 20.65
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3163,9 +2589,7 @@
         "token": "22acfd8c-f31e-41ee-bf3e-be286b2c4184",
         "price": 65.2
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3174,9 +2598,7 @@
         "token": "6e208342-105f-4b11-b21c-32a3a17f984a",
         "price": 82.05
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3185,9 +2607,7 @@
         "token": "ad6efe7d-15da-49c8-ae97-72c4076a9396",
         "price": 89.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3196,9 +2616,7 @@
         "token": "0d17321d-3022-436a-ae13-31d84cc42065",
         "price": 27.76
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3207,9 +2625,7 @@
         "token": "ccb19027-8f96-4c07-ab16-0f9eeee33197",
         "price": 47.35
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3218,9 +2634,7 @@
         "token": "c18b25a4-3a8a-4e60-a7cd-1492bdaa82fb",
         "price": 35.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3229,9 +2643,7 @@
         "token": "25cbc1f5-a989-4cac-b9de-241fcdf69cf0",
         "price": 23.02
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3240,9 +2652,7 @@
         "token": "0a7d27e8-404d-4eed-836a-c2a5141d97c2",
         "price": 45.57
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3251,9 +2661,7 @@
         "token": "320f0cc6-65bb-4b51-a567-bd841f0e99ba",
         "price": 15.76
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3262,9 +2670,7 @@
         "token": "7ebc86d9-abc3-482b-9235-b343ac367ade",
         "price": 36.2
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3273,9 +2679,7 @@
         "token": "910e7e9e-4101-42a9-8dce-bc15ab5005b3",
         "price": 21.22
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3284,9 +2688,7 @@
         "token": "50946cfe-b7e2-45d3-80e9-f90efa219d9c",
         "price": 15.59
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3295,9 +2697,7 @@
         "token": "a0f7083f-294e-47f1-9904-66aa731b8754",
         "price": 11.93
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3306,9 +2706,7 @@
         "token": "c8107652-06f4-40d1-881a-5d5ccb28dda9",
         "price": 54.85
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3317,9 +2715,7 @@
         "token": "a01debcd-14f4-4273-9b08-f253d3839a7c",
         "price": 71.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3328,9 +2724,7 @@
         "token": "3a0c82c4-33e7-42bd-9982-0dbbc36d7381",
         "price": 26.53
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3339,9 +2733,7 @@
         "token": "19bd2147-78a4-45fa-975f-ddaf2244781e",
         "price": 55.77
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3350,9 +2742,7 @@
         "token": "285d3056-56c0-47fd-9dba-0b42e5dcfb4c",
         "price": 18.75
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3361,9 +2751,7 @@
         "token": "18c93cca-190d-434f-9174-59be585241a7",
         "price": 46.67
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3372,9 +2760,7 @@
         "token": "bb0fae67-7fc1-4f71-bc07-6c99f3baf813",
         "price": 76.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3383,9 +2769,7 @@
         "token": "fabd75c0-ba8e-4c6d-a162-7b5a421759fa",
         "price": 57.83
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3394,9 +2778,7 @@
         "token": "97ae01ee-2804-49a0-94ca-0e0151998290",
         "price": 17.21
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3405,9 +2787,7 @@
         "token": "4c617892-d0f2-471d-a5b7-7898b23da3f2",
         "price": 86.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3416,9 +2796,7 @@
         "token": "11d6ca12-59db-4d5a-b639-2f082516986e",
         "price": 98.21
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3427,9 +2805,7 @@
         "token": "20c5ceae-12af-472f-a398-88f122e8f521",
         "price": 60.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3438,9 +2814,7 @@
         "token": "d0d2c7ea-5d4c-40f3-92f2-6fa1710841b4",
         "price": 83.11
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3449,9 +2823,7 @@
         "token": "d42a572f-af22-4163-b1e2-89271c8eb967",
         "price": 33.42
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3460,9 +2832,7 @@
         "token": "1e362602-585b-4ee7-a667-775e4890fb50",
         "price": 90.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3471,9 +2841,7 @@
         "token": "e739be65-04a6-4d44-ac6f-e8ba7dc1a464",
         "price": 56.33
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3482,9 +2850,7 @@
         "token": "a26926f8-3e51-427d-aed9-1b2e7e6f59b5",
         "price": 58.67
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3493,9 +2859,7 @@
         "token": "ada3a436-8e86-45c2-903a-d51142a774cf",
         "price": 43.75
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3504,9 +2868,7 @@
         "token": "b911d310-869c-4683-b500-e6eb186b9683",
         "price": 80.71
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3515,9 +2877,7 @@
         "token": "179c4950-e3c7-4b13-b0ae-6048232434e8",
         "price": 95.3
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3526,9 +2886,7 @@
         "token": "2bd75f5b-08c0-4457-9551-82fd268101f8",
         "price": 12.7
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3537,9 +2895,7 @@
         "token": "1fc0d374-4d0a-4534-933e-8604c14e4b2b",
         "price": 93.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3548,9 +2904,7 @@
         "token": "57d73afa-13b5-4c25-b4fb-9c78ea9c811b",
         "price": 63.13
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3559,9 +2913,7 @@
         "token": "1c67a831-370f-4190-89c7-53c35f2270f4",
         "price": 44.4
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3570,9 +2922,7 @@
         "token": "77a7a9fc-f0d1-4680-b8fc-c10cfe5ce2f7",
         "price": 13.55
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3581,9 +2931,7 @@
         "token": "cabd732f-e37b-40ca-82fb-b6d4b3081f17",
         "price": 74.85
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3592,9 +2940,7 @@
         "token": "4f6f9e6a-a378-4b9d-a46c-8ca1b8275282",
         "price": 52.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3603,9 +2949,7 @@
         "token": "4fda01f3-e371-4697-a8a8-458879706bf9",
         "price": 91.79
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3614,9 +2958,7 @@
         "token": "77d72ad1-521f-46cd-b468-71bdf98ef542",
         "price": 52.82
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3625,9 +2967,7 @@
         "token": "81549cd0-636b-4072-a2ec-237ad247d6b6",
         "price": 79.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3636,9 +2976,7 @@
         "token": "3f6acb3c-985b-4d20-b379-f77931cbb819",
         "price": 20.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3647,9 +2985,7 @@
         "token": "1aa65862-fee9-404a-9003-3dc396390a36",
         "price": 61.26
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3658,9 +2994,7 @@
         "token": "dd1cb22e-c177-4b6f-9bf9-915a7ec45bff",
         "price": 89.81
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3669,9 +3003,7 @@
         "token": "4b66c4c9-27f0-4dda-bbb7-d9402294c8f5",
         "price": 58.83
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3680,9 +3012,7 @@
         "token": "573298b1-6d97-4d3c-bfaf-855fbc6eb3ca",
         "price": 99.16
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3691,9 +3021,7 @@
         "token": "87d1b1b0-a3e6-4a12-b7f3-d77e49916f11",
         "price": 44.31
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3702,9 +3030,7 @@
         "token": "9e3ed5c9-8765-4b74-8046-f3a7c0dcab1e",
         "price": 78.54
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3713,9 +3039,7 @@
         "token": "f8e5546f-dd37-4703-b6a0-b588161c873a",
         "price": 87.93
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3724,9 +3048,7 @@
         "token": "a0acdb88-8cec-41ce-a4d2-c0c5095a3aec",
         "price": 66.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3735,9 +3057,7 @@
         "token": "f4c249bb-3810-47cd-a449-ed459e8709e4",
         "price": 48.61
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3746,9 +3066,7 @@
         "token": "005ee864-59ae-4bf1-adb0-3ae580d472d6",
         "price": 15.39
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3757,9 +3075,7 @@
         "token": "756ccc61-88e2-4970-a7bb-eb908eb0298e",
         "price": 59.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3768,9 +3084,7 @@
         "token": "42564205-d5e1-45d8-a26f-e201398b1d4d",
         "price": 96.54
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3779,9 +3093,7 @@
         "token": "0baea316-7917-46b0-924e-d0a2db10755f",
         "price": 40.29
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3790,9 +3102,7 @@
         "token": "80a6c991-0859-424e-98b4-d9fe9c58c03f",
         "price": 81.15
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3801,9 +3111,7 @@
         "token": "b3bba941-b3d9-4814-9911-d75a1b67a87c",
         "price": 28.42
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3812,9 +3120,7 @@
         "token": "143c1c99-c22b-49cd-8db2-c76ff2d7bc50",
         "price": 49.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3823,9 +3129,7 @@
         "token": "9512152f-05b6-4240-816f-d746af762c47",
         "price": 30.41
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3834,9 +3138,7 @@
         "token": "3e934d43-8554-4d24-8a2b-0584d02bfee1",
         "price": 95.07
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3845,9 +3147,7 @@
         "token": "18f2b266-e29e-495e-8158-1d77439d4616",
         "price": 37
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3856,9 +3156,7 @@
         "token": "c85fa1c3-8aa9-4aa2-bf2f-aa6e0010699d",
         "price": 21.98
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3867,9 +3165,7 @@
         "token": "2b2f8a6d-ac1b-4157-ac4d-25b90d994975",
         "price": 32.84
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3878,9 +3174,7 @@
         "token": "3dc22cae-42a9-45ff-b50b-c336f6c9031b",
         "price": 25.74
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3889,9 +3183,7 @@
         "token": "49af3291-0192-4386-ac3d-ebeea6a52d20",
         "price": 65.57
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3900,9 +3192,7 @@
         "token": "db8dc371-a4b3-49b3-b07e-7c212b76fc15",
         "price": 95.7
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3911,9 +3201,7 @@
         "token": "73c6f853-6971-40da-961b-962cdadb865f",
         "price": 97.91
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3922,9 +3210,7 @@
         "token": "68706cce-138f-43b7-99be-762991207310",
         "price": 92.02
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3933,9 +3219,7 @@
         "token": "d58488c8-811f-4fdd-bfb5-f7417afb5191",
         "price": 68.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3944,9 +3228,7 @@
         "token": "12189b89-88c9-4eb7-8ec5-2ce6a4617ceb",
         "price": 98.01
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3955,9 +3237,7 @@
         "token": "ba8bd248-3437-470d-b244-9b00c2beba97",
         "price": 16.01
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3966,9 +3246,7 @@
         "token": "aeabc326-d7c9-47cd-a463-65cac18f8c7e",
         "price": 99.29
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3977,9 +3255,7 @@
         "token": "9daf6248-c46d-4331-9a9e-c0a0665e5cda",
         "price": 86.19
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3988,9 +3264,7 @@
         "token": "b1930d09-1eb5-4373-abe9-fa671ffbc0e2",
         "price": 37.22
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -3999,9 +3273,7 @@
         "token": "e8e25003-9bf8-432a-81dd-fd6cdb11c422",
         "price": 91.91
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4010,9 +3282,7 @@
         "token": "b57ce961-5754-4329-8181-85bfbf74fd24",
         "price": 45
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4021,9 +3291,7 @@
         "token": "f9e95298-c989-442c-810a-774d35a5bbc6",
         "price": 14.15
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4032,9 +3300,7 @@
         "token": "c0bd86b1-428b-421e-9fdb-c35b17975f82",
         "price": 19.4
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4043,9 +3309,7 @@
         "token": "3e0c06a2-9268-436d-bb98-f9c88b030fb8",
         "price": 84.27
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4054,9 +3318,7 @@
         "token": "3f5eda86-c053-404d-95e1-6ff3fd5480bd",
         "price": 12.3
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4065,9 +3327,7 @@
         "token": "ad154b12-f148-4d09-922e-5e8aefd02373",
         "price": 42.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4076,9 +3336,7 @@
         "token": "b0fbee5a-c394-4174-9184-b0a8c03621f5",
         "price": 83.78
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4087,9 +3345,7 @@
         "token": "74674438-9650-407f-a387-c55dac1e45d1",
         "price": 80.02
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4098,9 +3354,7 @@
         "token": "a258597f-a232-4809-8033-b20a5b4eea5e",
         "price": 64.55
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4109,9 +3363,7 @@
         "token": "c80b695f-b2c9-4e67-82a1-91d6b8255e65",
         "price": 79.12
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4120,9 +3372,7 @@
         "token": "cba03408-b66d-4129-a26c-dbdac59a0766",
         "price": 33.13
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4131,9 +3381,7 @@
         "token": "470f4308-cb32-49c3-a373-b9522f219790",
         "price": 42.17
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4142,9 +3390,7 @@
         "token": "6f5d39dc-4355-4cb8-862d-ddbb5fa26a29",
         "price": 73.59
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4153,9 +3399,7 @@
         "token": "7da3a49e-74c6-45c4-ba21-c3ff8c84c2c7",
         "price": 23.02
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4164,9 +3408,7 @@
         "token": "f7b71706-b701-43e0-8082-2bc7829d0404",
         "price": 80.15
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4175,9 +3417,7 @@
         "token": "52711f47-b540-4c7b-9592-5b441fc77465",
         "price": 52.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4186,9 +3426,7 @@
         "token": "e7a7b37b-f897-4da2-8fee-24ab1f7337de",
         "price": 27.41
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4197,9 +3435,7 @@
         "token": "8a55a39e-9f0e-40fb-9aa2-be431b74a7de",
         "price": 47.43
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4208,9 +3444,7 @@
         "token": "00ba573d-e51b-4ae0-b02c-c5cfef5122f2",
         "price": 67.38
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4219,9 +3453,7 @@
         "token": "7a1fc56f-e64b-44dd-b2b6-bedfd1d3d776",
         "price": 76.14
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4230,9 +3462,7 @@
         "token": "c0fd71c4-bca7-45b6-92b1-69486dad1297",
         "price": 26.43
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4241,9 +3471,7 @@
         "token": "d84b133e-ef76-42a2-a885-4b12b3442d69",
         "price": 48.79
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4252,9 +3480,7 @@
         "token": "b017fb66-7faa-4dad-81bb-5a9ca2634482",
         "price": 36.46
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4263,9 +3489,7 @@
         "token": "328f19fd-b055-4765-b0b9-e3526d44da29",
         "price": 11.83
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4274,9 +3498,7 @@
         "token": "f63341e0-7604-49bb-9f06-7d2c34ca6a7b",
         "price": 89.14
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4285,9 +3507,7 @@
         "token": "a7cbb797-444f-4971-9be4-11a5ed6fb975",
         "price": 34.44
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4296,9 +3516,7 @@
         "token": "5d18a594-1b56-4d1b-a509-138b05342eba",
         "price": 97.59
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4307,9 +3525,7 @@
         "token": "e083a326-7e63-45b2-a8eb-00b3b6fd0202",
         "price": 92.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4318,9 +3534,7 @@
         "token": "d662e7aa-8901-493f-90cd-3325cb36bfa0",
         "price": 96.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4329,9 +3543,7 @@
         "token": "cd3e87a7-eb4a-4f52-aa80-6c1c9fae2f0b",
         "price": 46.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4340,9 +3552,7 @@
         "token": "67ec4b38-887f-4067-aeb9-f141ae6843a5",
         "price": 22.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4351,9 +3561,7 @@
         "token": "018bb3df-6ac1-45ce-bd3b-befb79fca2b7",
         "price": 80.16
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4362,9 +3570,7 @@
         "token": "d859dfc8-1cef-4d9b-ae06-ccae4840cd2d",
         "price": 31.92
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4373,9 +3579,7 @@
         "token": "62f1ae3f-0aab-4a0f-95ea-5b488acffa35",
         "price": 59.86
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4384,9 +3588,7 @@
         "token": "252a9ac2-fbea-4058-ac49-01e32b9b1123",
         "price": 91.61
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4395,9 +3597,7 @@
         "token": "4c7f744f-fa62-42cc-8c4f-2c186a5a757c",
         "price": 86.74
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4406,9 +3606,7 @@
         "token": "b1c694a6-8187-496c-8e49-f613a4abfc89",
         "price": 74.7
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4417,9 +3615,7 @@
         "token": "bdc5850d-6d71-4c8c-a9cf-37d9c98a37a6",
         "price": 29.77
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4428,9 +3624,7 @@
         "token": "4c691f7d-798c-428b-8330-9224e51c5319",
         "price": 98.45
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4439,9 +3633,7 @@
         "token": "fb4d9508-5909-4ec7-8a35-ef6d376adc94",
         "price": 49.2
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4450,9 +3642,7 @@
         "token": "f4643738-8b84-43f2-b573-911595500330",
         "price": 24.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4461,9 +3651,7 @@
         "token": "590531b0-d5e0-427b-96aa-5f19aa050d61",
         "price": 39.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4472,9 +3660,7 @@
         "token": "1f271986-fab7-47b6-ae9a-9700b8c5a0d9",
         "price": 23.62
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4483,9 +3669,7 @@
         "token": "297163f4-89f6-406c-b4fa-b34233f34a39",
         "price": 28.36
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4494,9 +3678,7 @@
         "token": "92abbb80-2a62-4d24-a863-3a3d6270b051",
         "price": 64.38
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4505,9 +3687,7 @@
         "token": "9e4aa91b-7a92-498a-b562-e93645234de0",
         "price": 73.75
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4516,9 +3696,7 @@
         "token": "9d3c1ca9-c2ba-48cc-b31a-531f7d2c7ce6",
         "price": 40.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4527,9 +3705,7 @@
         "token": "6c9c79c5-74f0-4f97-bbb5-27c88791f1cc",
         "price": 87.06
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4538,9 +3714,7 @@
         "token": "85d5f79d-66d7-44b2-b986-6b6b4c6fa327",
         "price": 30.41
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4549,9 +3723,7 @@
         "token": "8937988f-abb7-42c6-8868-0c7d218878e6",
         "price": 74.89
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4560,9 +3732,7 @@
         "token": "d4a0417a-a989-4c2e-b394-b33e276b90ae",
         "price": 58.84
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4571,9 +3741,7 @@
         "token": "f9e069b8-64ca-49ec-906e-c1108d409eef",
         "price": 18.13
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4582,9 +3750,7 @@
         "token": "94fff29a-bdf1-4fdd-9e8c-57fa517ffa9b",
         "price": 84.53
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4593,9 +3759,7 @@
         "token": "1ac0d29e-a2a9-44a6-af4e-b156ef0379d3",
         "price": 97.48
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4604,9 +3768,7 @@
         "token": "51539d6b-8753-44f3-84a4-4a3a0ebe90c3",
         "price": 84.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4615,9 +3777,7 @@
         "token": "00040fa5-1cb4-439d-92f1-d541140b748f",
         "price": 14.52
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4626,9 +3786,7 @@
         "token": "8f1ba953-945e-4160-adcc-effdce5f165d",
         "price": 66.27
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4637,9 +3795,7 @@
         "token": "d1e62842-aca5-451c-b9c5-bd466acbcc2e",
         "price": 24.76
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4648,9 +3804,7 @@
         "token": "0b0fb620-2257-40ab-b09b-3cabeba6464f",
         "price": 66.61
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4659,9 +3813,7 @@
         "token": "7d5a456f-692b-4019-980a-d3fa9c12186d",
         "price": 79.72
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4670,9 +3822,7 @@
         "token": "7486caf8-278b-40fe-b4bb-7b3489556f8b",
         "price": 81.88
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4681,9 +3831,7 @@
         "token": "5e60440c-a378-4a39-848e-0fa324ef8f42",
         "price": 19.19
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4692,9 +3840,7 @@
         "token": "012237f4-aed3-4fd6-860a-d2fe5026aadb",
         "price": 19.2
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4703,9 +3849,7 @@
         "token": "afc9a8aa-caf2-48c2-bac0-c72f44fd6c82",
         "price": 77.18
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4714,9 +3858,7 @@
         "token": "d6a2611b-f08a-45d8-9daa-8fd0c6eaf087",
         "price": 18.62
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4725,9 +3867,7 @@
         "token": "5b6bce6d-f030-4561-a045-8d35ac83f455",
         "price": 93.6
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4736,9 +3876,7 @@
         "token": "8fd6386f-c69b-4321-919e-d9abc8a205c1",
         "price": 33.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4747,9 +3885,7 @@
         "token": "7a66b7dd-b289-4182-ab06-e2180670f726",
         "price": 72.83
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4758,9 +3894,7 @@
         "token": "e54a4339-43ef-43e8-ae1f-caddcc53433c",
         "price": 95.61
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4769,9 +3903,7 @@
         "token": "f51c14ab-1b27-4810-8a6a-e91b620d9747",
         "price": 30.75
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4780,9 +3912,7 @@
         "token": "47b50dc1-93a8-4c73-8945-d4b1e6272cb5",
         "price": 22.26
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4791,9 +3921,7 @@
         "token": "b60a5a7b-2efa-413b-8030-9435aca51073",
         "price": 27.4
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4802,9 +3930,7 @@
         "token": "0628a26a-48a6-44d0-80ed-fb87664067ff",
         "price": 44.17
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4813,9 +3939,7 @@
         "token": "49990b69-6cca-40b9-8f4f-a7d31ae6b1a1",
         "price": 56.17
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4824,9 +3948,7 @@
         "token": "e18851de-8a99-448a-ad5b-e5f79b874996",
         "price": 62.66
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4835,9 +3957,7 @@
         "token": "dc53730a-8ee6-45a5-a00d-b613ca486f95",
         "price": 29.31
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4846,9 +3966,7 @@
         "token": "e7381e6f-58b3-4170-ac03-7a2091d4a10a",
         "price": 54.62
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4857,9 +3975,7 @@
         "token": "2b86d24b-fcb5-4ef5-9c2d-3135f7ced362",
         "price": 14.22
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4868,9 +3984,7 @@
         "token": "45c59186-cffd-4e12-a5a2-085a659418c3",
         "price": 47.47
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4879,9 +3993,7 @@
         "token": "e8e763c5-9f02-450f-8ac9-29ee284eeac2",
         "price": 25.68
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4890,9 +4002,7 @@
         "token": "e5f79693-9024-4fbe-b5b3-5228e7d5a090",
         "price": 95.3
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4901,9 +4011,7 @@
         "token": "dcecf7e8-1cc7-4c9b-b806-940120c53201",
         "price": 42.88
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4912,9 +4020,7 @@
         "token": "c60b175c-d128-44b0-9264-114129b5d0a5",
         "price": 67.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4923,9 +4029,7 @@
         "token": "4a53c7aa-2be7-456f-9c30-10e1ddcf4d6f",
         "price": 71.33
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4934,9 +4038,7 @@
         "token": "31c0405d-adb3-4021-8c47-d1233e33bf70",
         "price": 69.51
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4945,9 +4047,7 @@
         "token": "c2db16ff-425b-4005-a5a0-43f6d6449a06",
         "price": 48.37
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4956,9 +4056,7 @@
         "token": "54fe4c83-3334-4c67-9e30-37f43e02c5ac",
         "price": 72.88
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4967,9 +4065,7 @@
         "token": "bc79b2c1-7edc-43b2-8b48-fa0c8050e999",
         "price": 85.08
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4978,9 +4074,7 @@
         "token": "a4d308d6-4bc0-4f0f-b1e8-df69aeb64dfc",
         "price": 52.26
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -4989,9 +4083,7 @@
         "token": "1b7984c6-6712-4e87-9a43-f1217598c4c7",
         "price": 22.23
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5000,9 +4092,7 @@
         "token": "ef717e34-a35f-4dcc-b78b-d8a051ebd1f9",
         "price": 47.98
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5011,9 +4101,7 @@
         "token": "cee3ed78-e209-4a2e-80db-d9c8123ce1d6",
         "price": 58.59
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5022,9 +4110,7 @@
         "token": "21e9d8ac-e43d-42eb-9703-a59992ac6329",
         "price": 55.24
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5033,9 +4119,7 @@
         "token": "235bffde-e1da-48af-86ac-698eb0a91d3d",
         "price": 18.37
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5044,9 +4128,7 @@
         "token": "4ab1fce0-f6fa-4120-92e8-34852fed6e2d",
         "price": 28.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5055,9 +4137,7 @@
         "token": "64420c60-f88b-4571-98b4-9a74031fd989",
         "price": 19.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5066,9 +4146,7 @@
         "token": "2df0d044-4fe5-4697-8462-88fe7aca8d09",
         "price": 28.66
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5077,9 +4155,7 @@
         "token": "13cfafef-d4e9-4705-ac64-d09339cf600b",
         "price": 26.55
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5088,9 +4164,7 @@
         "token": "f3219f48-03f1-4cef-84ae-9aa8f4899bc9",
         "price": 70.46
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5099,9 +4173,7 @@
         "token": "d5ccfdc1-76ed-4de5-881b-48676178cdf2",
         "price": 42.02
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5110,9 +4182,7 @@
         "token": "dd36073c-7bcb-4254-8460-26f0695d7c62",
         "price": 27.78
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5121,9 +4191,7 @@
         "token": "d5c7388e-baba-4ec2-8d2b-049432d29f32",
         "price": 67.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5132,9 +4200,7 @@
         "token": "cc40de25-e7a8-4f32-ac09-3f15c64f8ec3",
         "price": 38.19
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5143,9 +4209,7 @@
         "token": "7c51451e-b5d3-403c-a49d-b4a553db86dd",
         "price": 15.11
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5154,9 +4218,7 @@
         "token": "db63596e-9dd0-4931-8996-cdba349d8561",
         "price": 75.14
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5165,9 +4227,7 @@
         "token": "5f33df57-1bb6-4d51-8b54-3100674f748c",
         "price": 30.65
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5176,9 +4236,7 @@
         "token": "6641ab87-31af-4fe5-8ef5-ef61a34c37cd",
         "price": 57.79
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5187,9 +4245,7 @@
         "token": "78c3ce1c-3c03-4090-be20-7772eadd3fc1",
         "price": 21.01
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5198,9 +4254,7 @@
         "token": "b8079ba5-627b-4472-b50c-d50bf7da9a74",
         "price": 34.95
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5209,9 +4263,7 @@
         "token": "4dcd674a-3393-4df1-a9a4-8fa45751282b",
         "price": 44.43
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5220,9 +4272,7 @@
         "token": "163319f5-c525-47fa-812d-c8f826a05e5c",
         "price": 66.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5231,9 +4281,7 @@
         "token": "7aebcdf9-6a3e-4c59-b345-186e35df64e9",
         "price": 59.46
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5242,9 +4290,7 @@
         "token": "74c32db5-cb30-44d5-8c46-2c4f01e45755",
         "price": 29.92
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5253,9 +4299,7 @@
         "token": "26ede999-3176-4473-b40b-3aacd3c14c7a",
         "price": 30.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5264,9 +4308,7 @@
         "token": "25a09cf7-57ca-4968-ae95-32fe2a48934a",
         "price": 90.8
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5275,9 +4317,7 @@
         "token": "9a2a69fd-5834-4859-855d-4de68d2c6a13",
         "price": 50.73
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5286,9 +4326,7 @@
         "token": "7533e896-adc2-481e-8cb8-febbd716a897",
         "price": 78.3
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5297,9 +4335,7 @@
         "token": "ac983912-d656-4d19-89fa-0ccaafaacb67",
         "price": 47.1
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5308,9 +4344,7 @@
         "token": "aa0fd697-a73d-475b-beb9-0b9f529ef67b",
         "price": 99.11
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5319,9 +4353,7 @@
         "token": "2992082b-55e3-499c-8587-afc4a8734645",
         "price": 97.96
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5330,9 +4362,7 @@
         "token": "d45918ce-8843-47ff-8e0d-795b9f1f8419",
         "price": 42.49
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5341,9 +4371,7 @@
         "token": "3cc4b5c1-f357-45f4-b02b-6b61eb5cf635",
         "price": 73.09
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5352,9 +4380,7 @@
         "token": "99c954a4-c62f-45a9-9fb8-c6a14110d2d8",
         "price": 44.06
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5363,9 +4389,7 @@
         "token": "7ff89eb6-4116-4e42-8549-25e10bf663f0",
         "price": 61.07
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5374,9 +4398,7 @@
         "token": "24afb3a8-c1ed-4b6c-8cb5-0a47d2c6080c",
         "price": 96.44
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5385,9 +4407,7 @@
         "token": "024e01f6-b3d9-4857-bb36-44edba1ba404",
         "price": 86.86
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5396,9 +4416,7 @@
         "token": "64d3ce82-378d-42c3-ac3a-f4c90a9a7a45",
         "price": 79.43
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5407,9 +4425,7 @@
         "token": "3fcbdeb5-221f-4fe6-9d2c-886441b8cd0f",
         "price": 24.03
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5418,9 +4434,7 @@
         "token": "7f59392c-5c34-43ce-bbdd-b9d1ebecd0a1",
         "price": 67.25
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5429,9 +4443,7 @@
         "token": "3ee3b0db-c865-4627-82ee-d1b95993475f",
         "price": 15.33
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5440,9 +4452,7 @@
         "token": "317d2464-6706-4ca1-8234-9c9476418e76",
         "price": 13.65
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5451,9 +4461,7 @@
         "token": "cd50bb4b-7482-4900-bf51-b0c59b248736",
         "price": 53.76
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5462,9 +4470,7 @@
         "token": "b7c13707-6f23-486b-a3f2-dfc0a0b41337",
         "price": 99.78
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5473,9 +4479,7 @@
         "token": "7970275b-29e4-4319-834c-0031dea24b0c",
         "price": 97.87
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5484,9 +4488,7 @@
         "token": "2738e734-21fa-4ae3-b1ab-666ccb6c1bf0",
         "price": 45.2
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     },
     {
       "log_level": "info",
@@ -5495,8 +4497,6 @@
         "token": "c357bdea-4bfe-45f9-8249-fc1a34983402",
         "price": 73.24
       },
-      "message": {
-        "event": "PaymentAccepted"
-      }
+      "message": "{\"event\":\"PaymentAccepted\"}"
     }
   ]

--- a/data/success/payment-accepted.json
+++ b/data/success/payment-accepted.json
@@ -1,4002 +1,5502 @@
 [
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "037eafd2-d721-48d8-b52f-4785e8238ca1",
         "price": 85.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b541b2b2-e331-4852-87d8-7987a6780ef4",
         "price": 82.81
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "76671516-8d75-4a57-92a5-fbc4abd33b7a",
         "price": 80.94
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "66e28edf-3743-4a8d-af60-3e3075e40bff",
         "price": 21.58
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c6b86574-cd5e-404c-8c37-46475d1eae16",
         "price": 63.72
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "47b00ab1-0c8b-42ef-bd6d-f1622a083723",
         "price": 14.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f874305e-65f1-4271-b582-ce213ba28723",
         "price": 50.58
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f36d3275-9b27-4955-9741-3a33434a600d",
         "price": 93.36
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "65d4eb34-5057-4d72-9808-6f3042ce27ec",
         "price": 55.39
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8bf1d391-799b-4286-9a0c-3a2cd15cd201",
         "price": 91.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "300a485f-3658-4edc-af22-1382c17cbdf9",
         "price": 11.42
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ae9d3037-adee-40d2-ac45-b522fedb8982",
         "price": 19.5
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a5e951c7-9524-4662-8e1e-260c64c85325",
         "price": 12.36
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e25a66fd-2a77-440c-96a2-8b6a58e10092",
         "price": 75.2
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "90852476-c300-4ef0-95d3-71002cc4ebb3",
         "price": 96.33
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f6b22800-200f-4305-b84b-bfe608a9fb20",
         "price": 96.05
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f0b942c0-5a1f-4c4d-9c20-dcc02e303f89",
         "price": 59.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c9f4b616-ce78-4243-9286-70ebc4844556",
         "price": 40.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5789c051-30f5-4314-9832-8eeb0183f978",
         "price": 83.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cd367e31-e373-497b-b5b7-dd4c20a11f4f",
         "price": 85.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "43d410fd-221c-4b5b-9091-327282cf540b",
         "price": 61.5
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "221ebd49-654e-4cdf-b3f1-6858ad2dd1ed",
         "price": 47.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8918bf18-1c01-4e33-ac47-c677ce7843e0",
         "price": 75.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f78871f4-ec75-4df4-a7c0-b2b6e5649de4",
         "price": 48.45
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "85d0219b-9813-4582-955a-319146ee7fc0",
         "price": 19.73
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "45272463-03d5-4a22-8c7b-34d55fedabf6",
         "price": 67.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "39364ae6-4a2e-41d8-83d0-98ca650942af",
         "price": 98.83
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9f755d32-8e72-4410-9f75-64b510e7157b",
         "price": 19.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3dca6aa2-35e2-44ad-bb0d-947527a2f58d",
         "price": 44.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "40722e82-2975-456e-b4d0-96215e7e8e9d",
         "price": 28.83
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "75b2fd13-45d9-4d38-a00a-3333f5bac908",
         "price": 47.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c38347dc-fb09-4e1f-9854-1cac8f4f968f",
         "price": 61.29
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "57f99d16-d4f6-4c2a-898d-8ba8634d080c",
         "price": 75.69
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1fca6512-8a16-412d-89e9-8f4670c41e26",
         "price": 37.88
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "78b8dc3f-2fb6-4c2a-b382-6e16275f01f3",
         "price": 13.07
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b9bb57af-beb9-4129-b532-c2b04bfe7aa4",
         "price": 40.76
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "59df4751-c5ca-465c-826a-a6e488ed484e",
         "price": 84.63
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "080977f7-5b08-4575-9b45-ee80adf1f034",
         "price": 66.01
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a6cb4bf5-f7c7-4bcd-9b94-9869020939f3",
         "price": 16.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "031b2e75-e7b2-4196-911e-62542824600a",
         "price": 39.07
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d7fe1481-a1c0-4b6d-a13a-ec92010df6f2",
         "price": 31.37
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "fb210c21-ff47-44a4-8fa0-3f4e831c1bdb",
         "price": 58.72
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8077e01b-bda4-447a-8ef3-f3a978152656",
         "price": 15.65
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e1bc6c1b-7926-4bc4-9e9a-7ab936b96831",
         "price": 31.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "35de2d41-f4bf-4adf-b9a1-ba7a036da2e9",
         "price": 81.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1bb674a8-7885-4e15-90a1-04350695ce5b",
         "price": 88.19
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "227acaa7-d92e-4c83-a93d-9fde07614e7b",
         "price": 66.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e9494acb-1b47-47bd-9d13-b17aa38cea9a",
         "price": 58.84
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "00f57989-34ae-4124-bcee-e9e1fd7bb32f",
         "price": 44.28
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bab9706d-8d9e-4153-8f2d-ace1c156ff77",
         "price": 29.65
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d91bbc27-c3b9-4959-acf6-301693fa1dff",
         "price": 63.98
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "268b2a29-a68c-42e6-8dc5-a7f8780e4396",
         "price": 58.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0bfd8525-df10-40bc-b811-cace89f66b58",
         "price": 83.64
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4dcd3be3-c1cb-49d3-ab9e-77759cb50c2f",
         "price": 24.63
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8b451f5d-1677-4068-a17c-5bbd3a2fe5a2",
         "price": 94.36
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2a5239c9-df75-4c57-98b8-522a53ec82b1",
         "price": 30.57
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "10fb7421-3b9d-48da-b253-77810f2cc4b7",
         "price": 13.37
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "12bfeba6-3678-4a92-9e31-4b1eedf164ab",
         "price": 86.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a58bb9a4-d8f7-40fa-81ec-6201d1da1789",
         "price": 19.41
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9f8b0926-67c5-483f-939b-3651773edc8c",
         "price": 21.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "be56f583-d5cc-48d0-b18b-2a09305a4f0b",
         "price": 74.74
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "875598cd-1178-44d8-9906-670f705361d8",
         "price": 31.47
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7a5981fa-c11b-435d-a4da-53077dc405e6",
         "price": 41.02
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "54f8484b-f202-4364-9b96-5a6111c26c99",
         "price": 34.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6ce845f0-3534-4619-a04c-73acf020f2ee",
         "price": 45.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "94235d34-42f1-416d-b174-91a713b0bbb1",
         "price": 13.28
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cb41735d-b92f-4d03-9d0b-085b20ffff0e",
         "price": 70.11
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3a558f8c-8382-4257-9752-0f60a0c7b54f",
         "price": 51.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "04260751-c28a-4340-a512-d754859fde7f",
         "price": 83.88
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "abc74ae2-ee7d-4bba-a57a-60f9bacaec1d",
         "price": 34.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "fdfe50da-ac7a-4071-acb9-f4c40bd8c346",
         "price": 14.77
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ed7ce93e-46ad-4f46-a208-fa6f526cef12",
         "price": 24.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "002f8980-196e-48f9-901a-422e4ffc3bd5",
         "price": 20.13
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c77430ec-0318-4e9a-8990-a1d252e8e44c",
         "price": 92.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a80fe69a-46ed-43c4-9b64-874a1c8410bf",
         "price": 59.38
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b78063e9-9db4-47ea-896f-0f49c11c00bb",
         "price": 28.55
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d1f6745b-bfb4-4ccb-af96-96839ed12bb7",
         "price": 81.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ee4a7af5-aa7b-40b9-85a7-1b9d63c37646",
         "price": 45.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2216c437-97b5-4ae4-bbf7-3b09d0775b49",
         "price": 77.39
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4e30267a-5f49-4b35-bcdf-d8a9fba4a8d0",
         "price": 63.15
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "42849e45-9162-4ecf-8144-22acee35b43d",
         "price": 31.91
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d1df9378-0bd1-4c2e-8a2b-9885ade81779",
         "price": 66.05
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4cf09c40-28ba-4a23-98d8-1495edb9b3f8",
         "price": 65.31
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "84b60956-1f9d-47ed-b4fc-e26ed932a604",
         "price": 20.79
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e709d376-1412-49aa-99c6-b3a4218eebcf",
         "price": 93.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e2943091-17a1-47e0-96db-e60bffec875b",
         "price": 73.24
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0fd5727b-b757-4ea1-9cc3-dc8dca38679b",
         "price": 83.47
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "85112b58-85da-4ba8-b964-6c9ead0a8c9c",
         "price": 39.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "da13829d-d40f-4f2d-8e61-c94abaf21bc3",
         "price": 83.7
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ec9f023a-03c3-470f-affc-5309daa7f49a",
         "price": 73.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1c3785f8-62e9-4fc7-8e6b-974a647bd9a3",
         "price": 79.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e35fb860-3703-480b-9523-0a61dd3e5c78",
         "price": 72.44
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "778fa965-7492-4fe6-b9c5-b8e3b9ca2800",
         "price": 72.89
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "da98845c-7ac3-4d70-ab5e-d29cfa4a05bc",
         "price": 67.1
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b6f2e3a3-332b-4e80-84f1-7de91dd4d099",
         "price": 76.77
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "65819012-5f4a-49a7-9a79-936890628d86",
         "price": 34.21
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7e502853-9462-41e5-8597-f2f2ec34b3f8",
         "price": 79.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1a0ae311-7b80-4aae-b479-be9744cba86a",
         "price": 85.15
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6cf73040-7f3e-43fa-b5a4-4569500246ee",
         "price": 52.29
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "94d780bc-6dee-41a4-9919-f1d55a33170f",
         "price": 40.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "20fb559d-1a8b-4874-be94-df4f86cfcd15",
         "price": 32.81
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "99bf7b9d-0325-4375-87de-4015e806fbf0",
         "price": 67.28
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "763502f3-de2b-4c02-9ada-c02d572898eb",
         "price": 10.36
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d0cf242d-6f9f-49b1-86cc-95bbb1ca93da",
         "price": 86.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3b1c6d84-70f0-470d-916a-5d0ae8f38129",
         "price": 66.07
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f4b839b0-078c-46a8-a3bc-03847293f4c4",
         "price": 59.06
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "64e09a13-81af-4462-8179-caadd4c79873",
         "price": 71.01
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0c7fb03c-73a5-4a3b-9310-da4a4e2ff60c",
         "price": 20.22
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "75c41d96-2d70-49d0-81d4-3054b898d227",
         "price": 23.4
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9739995f-b643-41c4-8cc2-bf0a445915d6",
         "price": 74.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3b3e88f0-8201-45ce-8315-4b48f85d69c1",
         "price": 52.62
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2dd9006d-eac6-4208-b5c5-4ff665002e36",
         "price": 20.46
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "19957d05-ab94-4179-aaf3-15918d780719",
         "price": 91.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4c41571b-c7b3-462c-a43e-98e43d4c8b93",
         "price": 39.02
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "128534c9-a27e-40d1-8269-1b4ac305400d",
         "price": 56.63
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "59d68d1c-049f-42f8-be0a-37eda211b84e",
         "price": 70.05
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "49b016e0-0e9a-4564-a445-493573820051",
         "price": 84
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b1e73dfb-de05-473e-9407-572a00e3e9a4",
         "price": 31.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "83759e87-425c-4101-bc4d-6f8dcad47b18",
         "price": 97.11
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5916860f-1c8e-4f4e-8f9e-5df631bc2397",
         "price": 55.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6d619931-b460-44ec-bb81-2104021932f7",
         "price": 79.85
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "df86e125-2d84-4150-9540-89dd87fc8fd4",
         "price": 70.05
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "45f5ece7-e941-492a-811f-45b73c1dbf72",
         "price": 52.38
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "febf190d-75df-4ef6-bc45-e5d6103827a6",
         "price": 59.06
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e37591ba-d960-4075-96ea-01a6ac1a3701",
         "price": 78.69
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "57ee2e72-f8e0-44e4-a018-0bebb6a55a21",
         "price": 48.7
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a85d5c8b-1969-42e6-8923-ff17d96cf74a",
         "price": 67.1
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c71105d0-823e-485b-a0f8-8aeaaef375fe",
         "price": 58.89
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "16260140-acfd-48ab-9482-edb13b68de40",
         "price": 79.27
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "22439821-de16-4b24-bb9a-b089e9160ed2",
         "price": 80.16
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8ebc985f-7ed4-41b7-88d1-3b79cd14be02",
         "price": 89.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3aadaec3-4ef3-44ca-8616-234d244bbf66",
         "price": 99.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c82fbe3e-eb6d-45a7-b335-70278b804a96",
         "price": 70.76
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d116b5ad-4c5f-4f57-942d-f4a69297cc77",
         "price": 44.28
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c8dd8a9c-70aa-4454-bae3-c8bb8a9bd389",
         "price": 17.3
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "22f0b560-46df-4898-bb7c-10494039855f",
         "price": 10.21
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b253521f-f873-4ded-8ee9-5e5171672119",
         "price": 25.5
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "296655f9-88ec-4bb7-bd0c-6737c81f0c1a",
         "price": 90.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "93bab2e7-1911-4fe5-97cc-3f2330e0d817",
         "price": 97.99
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "70c381c5-3cb1-4d0a-ac6a-98175eadb166",
         "price": 43.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "46ad78f9-cb49-4a4c-8090-6ca70702aaef",
         "price": 44.71
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b4143b16-4026-447a-bff8-87d4c7e7479c",
         "price": 66.47
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d86cf016-e8ee-4130-a2ea-8e887955e5b9",
         "price": 43.38
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "50fc2f9e-e54c-4080-8ccf-ce69238117ae",
         "price": 29.58
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "94b877aa-8dee-46db-bc73-e60676da8fb3",
         "price": 16.34
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "640e4fd6-ab34-432f-a4bc-8f160d1d7849",
         "price": 56.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "df0cff30-3d80-4015-a719-a5685fe20df0",
         "price": 94.11
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f58421c8-8eaf-4d7a-9114-226e11a8180e",
         "price": 80.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7756b72d-7b40-4fda-ad7c-19b72bd05918",
         "price": 22.3
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "49e20ff7-fab7-44eb-88cf-d6e26f765f9f",
         "price": 87.12
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7522a0cd-5abd-446d-89f6-1e9178aec15b",
         "price": 80.06
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6d9b8e42-fdee-444e-9ddb-e732dd3b5a19",
         "price": 79.73
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "99a4a516-19b1-41bf-b1e3-39d8821e1d15",
         "price": 33.57
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bf7f40ff-3676-4486-8481-70dae32c9222",
         "price": 61.85
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8a170ab2-1a39-4ce2-b750-3d28b9790622",
         "price": 46.97
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c191922a-207c-4881-b7e4-8d9cc1f63e49",
         "price": 93.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6eb9f21e-e469-4d81-8bd3-2ecf9344b3b4",
         "price": 69.19
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6b3ec23b-85f2-4cb4-b8ce-61e9113f05fe",
         "price": 47.39
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e85850a2-4d4f-427e-abf4-0187c8c47b08",
         "price": 28.86
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "51ed347a-7072-4f89-a68d-a87ef1ef0720",
         "price": 54.57
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f1da1692-38ee-4e00-8da3-4d0bdf099b60",
         "price": 33.91
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "48818101-9fc4-41ff-8142-6f4f9ca5f3e4",
         "price": 15.86
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1fb43c21-a8d4-4aab-a735-0369cde83920",
         "price": 71.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b29e4cbb-d0bc-4883-8f71-19dab985c79c",
         "price": 66.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c692fd5c-c09e-4973-becd-34ef0f0f3674",
         "price": 14.38
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ef590265-29cf-45c0-9417-7dddeb6a0f59",
         "price": 68.01
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a3e687e7-63df-4e47-8a6b-93bd81123093",
         "price": 31.22
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1d5b2560-748f-4de3-8fab-e3a6a769de1a",
         "price": 43.47
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9a21afff-6fb1-4ff7-8959-d18803827f76",
         "price": 15.87
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "717288aa-4bd3-41ff-bc00-2dba14ac509b",
         "price": 75.4
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2511e794-9402-40f1-9e58-10c1f33186ed",
         "price": 19.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "52889f94-14db-4c5a-9e21-595af9a0cf39",
         "price": 96.3
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6a0afcda-29c5-48c5-b283-5c000fec1613",
         "price": 10.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "fd5bd488-042c-4e3f-a03d-be3496bfc5c7",
         "price": 17.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "edebc8a3-bd8b-417b-adf6-ad2d1dfec1ed",
         "price": 81.47
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "fd29d24e-faa3-4bc3-ad24-8b5d1c1a4d54",
         "price": 66.45
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8a726454-54ce-472a-92ec-a2af6ca0d527",
         "price": 62.16
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a08ef211-d996-483b-a63d-c8279261ed23",
         "price": 86.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "06d04bea-b522-495d-9b80-a67866dcf241",
         "price": 81.5
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2324b571-edf4-43ef-815f-1dbdc81fcb5c",
         "price": 82.77
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1c9f3a7a-2e24-4199-95d9-aeb4cbd50484",
         "price": 79.22
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "820acbfd-13a8-4043-b16d-3fd18a5d32ed",
         "price": 94.33
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b6952a9f-9d22-458f-8052-0e9a94b07e0b",
         "price": 31.21
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d02e8ea8-191a-45b7-9593-a96663cceac7",
         "price": 11.56
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f187e6f0-62ae-49e3-b273-0f47c25cbffc",
         "price": 53.64
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "53ac9b66-b4dd-4ac6-b07e-fd979d9195bc",
         "price": 75.58
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "38ae3bf5-b7ee-44a8-a0fc-5b5d021c8a79",
         "price": 60.89
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "01e30649-6dfc-4246-bc0b-54d04fea6699",
         "price": 21.45
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b7449156-2633-4bc6-a846-726e694572fa",
         "price": 81.81
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ca160e1b-388c-4f91-aa0d-4206d079d937",
         "price": 53.15
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "69ddc5b5-1600-4f79-b048-8cb310347349",
         "price": 92.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "36653add-07b4-4f5a-8cdb-8f6fdb343640",
         "price": 89.24
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ee9f2e89-0138-46fb-92d4-25230642651f",
         "price": 74.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "314fa286-2cdb-4596-85c5-9b8a497732df",
         "price": 60.46
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6cd365ee-1bcd-417a-962f-7a02ce8a24cf",
         "price": 15.29
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e51e4493-b059-4a6e-b386-06eda77e553b",
         "price": 89.47
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "adaea9b0-ce9a-43e5-b671-273335665abb",
         "price": 17.84
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "905c869a-12ca-4a59-928b-cad72424a6be",
         "price": 39.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e3770c4c-0423-4ebd-9766-5c9b1af8c720",
         "price": 16.35
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2fab66c0-f574-45d1-81a4-5d3cacc5b586",
         "price": 90.97
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cde31ff5-d3d9-436b-a975-43d9fe867555",
         "price": 99.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "89fe3b28-1ecc-401a-94f6-f632f25367a9",
         "price": 10.87
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b5d91dad-8f6c-4813-b50c-dc935a6a7f5f",
         "price": 90.54
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5492f845-9426-4e4a-ac39-5047be2d1f2f",
         "price": 60.16
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f591a4ee-53c4-4090-992a-17e3b6001a47",
         "price": 32.63
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3865cbcc-17d0-4bb7-a517-0b845246ffed",
         "price": 30.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "56c1442d-43c8-4f57-b582-e23cb0a72270",
         "price": 30.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "266f2c91-9e90-4a6f-b258-89a7f6ab4b69",
         "price": 30.98
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "45b84d57-fca4-4f77-bc2e-996258df211c",
         "price": 52.56
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0af1abaa-44e4-4562-b50d-77fbec330716",
         "price": 54.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f7b67e75-ec09-4102-866a-1af1b2845141",
         "price": 44.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b41ef9c0-24d4-4d4e-8dce-22fe7e0fec18",
         "price": 81.79
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9bd9e4bd-7843-4816-bc77-0b0a8dff1d87",
         "price": 88.56
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3727c2b8-482f-4a21-b310-e3926493cf37",
         "price": 34.34
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "51407595-63dd-4a8b-a6cd-a93087f7e1ea",
         "price": 50.5
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3174eb8b-6b77-4995-a9d8-c9cc2d3fb728",
         "price": 18.85
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f90ec091-fa9b-454d-838e-0c52118e0292",
         "price": 87.89
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a8c48f6d-d04d-4e35-bc39-dd96eada4f89",
         "price": 73.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "56228c59-0fdf-42b8-92cf-cc1ae20bbcf5",
         "price": 13.07
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bb241774-3474-45e2-85b4-b755e2122a05",
         "price": 73.44
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "45abe2eb-6410-4314-8c78-e10729f2cf94",
         "price": 44.65
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a5833851-08be-48f0-9d8f-f6dd8c769d84",
         "price": 99.88
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b5b079b4-6897-4f6e-8300-1d45e0d6b1b1",
         "price": 97.41
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b2bfaa0a-9ee0-4f20-928f-ba547c3a5b49",
         "price": 80.78
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2f3df04b-3ef8-4968-8f54-09736f91fd61",
         "price": 82.98
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3a12630e-5795-43a5-a13f-e2499e80b188",
         "price": 50.69
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "323e45b8-c707-451f-913c-eb13b01dcdd9",
         "price": 76.67
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "96b5fa90-6e86-4545-96a0-e2bc161f89df",
         "price": 31.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b5cf7795-4ed5-4e75-99cc-d978e8472431",
         "price": 94.36
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a62a3be4-cf8c-4c85-9b7b-1c7b3ff06cf5",
         "price": 27.86
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4e73262b-0dca-4bb9-a375-d117a0d84198",
         "price": 84.44
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c9b981ee-73d1-4ae5-8ec6-57c47936d6e3",
         "price": 79.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "df2a4dbe-c7f5-49a9-b2aa-fe685a2c7fdc",
         "price": 64.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4f6030de-407e-42b8-9fa4-ff16e051bfd9",
         "price": 97.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c05c07d2-5429-44ed-9d67-013850a43588",
         "price": 70.14
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f2b8e797-5098-404a-aab3-68d12a441e19",
         "price": 65.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8d4cae77-6608-4629-9332-03d74355d3b6",
         "price": 99.33
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "917b12d1-ac86-47e7-92a9-129f909036a5",
         "price": 84.36
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "94706cd8-c46b-44cb-ac41-e551fd88dbf5",
         "price": 16.53
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "993e2ca3-0042-4425-9495-08aef572633a",
         "price": 98.32
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "40ca13ea-c916-429a-b738-986f3d934fe1",
         "price": 10.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "28ba766e-8ed0-40bc-9000-71de8621fcd2",
         "price": 31.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8effb1e6-f295-46e7-85ee-fd72ce24cfcf",
         "price": 27.37
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bd36dd98-746a-4e56-a98d-00e6e9cbbece",
         "price": 24.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0a2584ea-4998-4e22-9360-1509719eb93d",
         "price": 41.63
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8bbab90c-a329-409a-b88c-4bd2607a9b27",
         "price": 24.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "79d1cb8f-019d-4d07-a13f-15e7d2ace9aa",
         "price": 58.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a5921299-2878-4469-9568-c133e0b44713",
         "price": 69.4
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "03d1ea63-92d9-4cfe-a7b8-789a1f67b769",
         "price": 22.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "53aee925-608a-4992-88e4-28e1e7702bc0",
         "price": 29.33
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "339da0f3-8642-49b1-9c55-e0f5c1ebd15e",
         "price": 65.63
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "daa18693-d260-4a04-ba87-57ab52871acd",
         "price": 46.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4516598c-fabe-4107-9b70-b5ea582bbff2",
         "price": 66.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5cb8b853-13a8-4e18-91df-950004f6ce3c",
         "price": 63.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6e4d25f4-2764-4bd4-aada-96e2f32972b5",
         "price": 48.54
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "af428861-b9ac-4c6d-840c-4a20daac487a",
         "price": 33.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5b599e2a-9be8-4525-94f2-d0b6280d6d5e",
         "price": 82.16
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "00c298f4-364a-443a-a0e5-96fbf894c61e",
         "price": 10.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "df55c0aa-b50f-4dc2-87f6-7884150aeaa5",
         "price": 60.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d307783f-5d21-479a-8d10-41f4a1416130",
         "price": 36.61
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "41370016-1965-4f2e-b54e-d4c949dc8e1a",
         "price": 59.75
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d2ad8b02-3d98-4631-9722-83970eaf7ec7",
         "price": 79.83
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "50ba3c81-0fa6-4eb5-9413-10dc677cf948",
         "price": 63.84
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a8dfb932-b50c-41a4-a17a-e3d1c3e97112",
         "price": 31.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e4055328-be5d-45d2-b798-040af920157a",
         "price": 40.08
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "043ecb14-763e-4dca-9f06-67126bd3cd81",
         "price": 90.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bed88942-6685-42fe-ac50-bfe3fd156669",
         "price": 41.17
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "aac95d63-93a5-472a-bb65-af9e8791d70c",
         "price": 52.56
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2256ad1a-d7d4-42cf-b419-54a173caa71e",
         "price": 95.06
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "68022bb6-e6f4-43b7-afa0-a9b484d38735",
         "price": 91.28
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4d4b3c37-33b8-470f-b550-a832d0a309be",
         "price": 54.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d1d13b6c-d338-4d2f-84d1-f5ee9d0b55cc",
         "price": 22.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "05fa7bc6-b530-4d0d-a9bc-ac7d2d3f7e2b",
         "price": 59.14
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cc77a3da-2516-41f7-8f4f-28062a71ed3a",
         "price": 84.34
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "549aaf14-57cf-4cd9-8fe4-63c9527ce9b7",
         "price": 11.71
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6b61a326-eb4a-4a88-badc-3eeef6fc98db",
         "price": 60.59
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ff90b6aa-f67b-4809-9c25-c0603477328b",
         "price": 10.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b060c27d-d3b7-45d4-95bd-8b16a65fd213",
         "price": 15.19
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ba660730-ca85-4863-bb8e-5ce7cbeb1d1b",
         "price": 86.01
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "18e860ed-bd6b-4a5e-bfc7-368842e61dba",
         "price": 48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9c48d586-7eb1-45fc-a9d2-60164685c900",
         "price": 83.24
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c2eb7aac-0d0c-4ddb-a766-20bf3229505d",
         "price": 72.14
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "19503237-da3b-492f-a275-ad2c0911961e",
         "price": 52.88
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "61ce4458-3615-4f38-a5ce-ed425f8931ba",
         "price": 20.41
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e3da5bf0-81c5-4d6a-a164-74a15c77cfcb",
         "price": 24.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e72fad4e-e09b-41f6-834c-0b1f85d2ff8d",
         "price": 42.84
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "35c2ccc6-f542-41f4-8e08-0d7c07f6daec",
         "price": 20.65
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "22acfd8c-f31e-41ee-bf3e-be286b2c4184",
         "price": 65.2
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6e208342-105f-4b11-b21c-32a3a17f984a",
         "price": 82.05
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ad6efe7d-15da-49c8-ae97-72c4076a9396",
         "price": 89.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0d17321d-3022-436a-ae13-31d84cc42065",
         "price": 27.76
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ccb19027-8f96-4c07-ab16-0f9eeee33197",
         "price": 47.35
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c18b25a4-3a8a-4e60-a7cd-1492bdaa82fb",
         "price": 35.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "25cbc1f5-a989-4cac-b9de-241fcdf69cf0",
         "price": 23.02
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0a7d27e8-404d-4eed-836a-c2a5141d97c2",
         "price": 45.57
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "320f0cc6-65bb-4b51-a567-bd841f0e99ba",
         "price": 15.76
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7ebc86d9-abc3-482b-9235-b343ac367ade",
         "price": 36.2
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "910e7e9e-4101-42a9-8dce-bc15ab5005b3",
         "price": 21.22
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "50946cfe-b7e2-45d3-80e9-f90efa219d9c",
         "price": 15.59
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a0f7083f-294e-47f1-9904-66aa731b8754",
         "price": 11.93
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c8107652-06f4-40d1-881a-5d5ccb28dda9",
         "price": 54.85
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a01debcd-14f4-4273-9b08-f253d3839a7c",
         "price": 71.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3a0c82c4-33e7-42bd-9982-0dbbc36d7381",
         "price": 26.53
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "19bd2147-78a4-45fa-975f-ddaf2244781e",
         "price": 55.77
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "285d3056-56c0-47fd-9dba-0b42e5dcfb4c",
         "price": 18.75
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "18c93cca-190d-434f-9174-59be585241a7",
         "price": 46.67
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bb0fae67-7fc1-4f71-bc07-6c99f3baf813",
         "price": 76.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "fabd75c0-ba8e-4c6d-a162-7b5a421759fa",
         "price": 57.83
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "97ae01ee-2804-49a0-94ca-0e0151998290",
         "price": 17.21
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4c617892-d0f2-471d-a5b7-7898b23da3f2",
         "price": 86.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "11d6ca12-59db-4d5a-b639-2f082516986e",
         "price": 98.21
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "20c5ceae-12af-472f-a398-88f122e8f521",
         "price": 60.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d0d2c7ea-5d4c-40f3-92f2-6fa1710841b4",
         "price": 83.11
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d42a572f-af22-4163-b1e2-89271c8eb967",
         "price": 33.42
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1e362602-585b-4ee7-a667-775e4890fb50",
         "price": 90.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e739be65-04a6-4d44-ac6f-e8ba7dc1a464",
         "price": 56.33
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a26926f8-3e51-427d-aed9-1b2e7e6f59b5",
         "price": 58.67
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ada3a436-8e86-45c2-903a-d51142a774cf",
         "price": 43.75
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b911d310-869c-4683-b500-e6eb186b9683",
         "price": 80.71
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "179c4950-e3c7-4b13-b0ae-6048232434e8",
         "price": 95.3
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2bd75f5b-08c0-4457-9551-82fd268101f8",
         "price": 12.7
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1fc0d374-4d0a-4534-933e-8604c14e4b2b",
         "price": 93.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "57d73afa-13b5-4c25-b4fb-9c78ea9c811b",
         "price": 63.13
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1c67a831-370f-4190-89c7-53c35f2270f4",
         "price": 44.4
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "77a7a9fc-f0d1-4680-b8fc-c10cfe5ce2f7",
         "price": 13.55
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cabd732f-e37b-40ca-82fb-b6d4b3081f17",
         "price": 74.85
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4f6f9e6a-a378-4b9d-a46c-8ca1b8275282",
         "price": 52.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4fda01f3-e371-4697-a8a8-458879706bf9",
         "price": 91.79
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "77d72ad1-521f-46cd-b468-71bdf98ef542",
         "price": 52.82
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "81549cd0-636b-4072-a2ec-237ad247d6b6",
         "price": 79.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3f6acb3c-985b-4d20-b379-f77931cbb819",
         "price": 20.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1aa65862-fee9-404a-9003-3dc396390a36",
         "price": 61.26
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "dd1cb22e-c177-4b6f-9bf9-915a7ec45bff",
         "price": 89.81
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4b66c4c9-27f0-4dda-bbb7-d9402294c8f5",
         "price": 58.83
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "573298b1-6d97-4d3c-bfaf-855fbc6eb3ca",
         "price": 99.16
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "87d1b1b0-a3e6-4a12-b7f3-d77e49916f11",
         "price": 44.31
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9e3ed5c9-8765-4b74-8046-f3a7c0dcab1e",
         "price": 78.54
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f8e5546f-dd37-4703-b6a0-b588161c873a",
         "price": 87.93
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a0acdb88-8cec-41ce-a4d2-c0c5095a3aec",
         "price": 66.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f4c249bb-3810-47cd-a449-ed459e8709e4",
         "price": 48.61
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "005ee864-59ae-4bf1-adb0-3ae580d472d6",
         "price": 15.39
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "756ccc61-88e2-4970-a7bb-eb908eb0298e",
         "price": 59.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "42564205-d5e1-45d8-a26f-e201398b1d4d",
         "price": 96.54
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0baea316-7917-46b0-924e-d0a2db10755f",
         "price": 40.29
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "80a6c991-0859-424e-98b4-d9fe9c58c03f",
         "price": 81.15
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b3bba941-b3d9-4814-9911-d75a1b67a87c",
         "price": 28.42
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "143c1c99-c22b-49cd-8db2-c76ff2d7bc50",
         "price": 49.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9512152f-05b6-4240-816f-d746af762c47",
         "price": 30.41
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3e934d43-8554-4d24-8a2b-0584d02bfee1",
         "price": 95.07
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "18f2b266-e29e-495e-8158-1d77439d4616",
         "price": 37
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c85fa1c3-8aa9-4aa2-bf2f-aa6e0010699d",
         "price": 21.98
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2b2f8a6d-ac1b-4157-ac4d-25b90d994975",
         "price": 32.84
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3dc22cae-42a9-45ff-b50b-c336f6c9031b",
         "price": 25.74
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "49af3291-0192-4386-ac3d-ebeea6a52d20",
         "price": 65.57
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "db8dc371-a4b3-49b3-b07e-7c212b76fc15",
         "price": 95.7
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "73c6f853-6971-40da-961b-962cdadb865f",
         "price": 97.91
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "68706cce-138f-43b7-99be-762991207310",
         "price": 92.02
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d58488c8-811f-4fdd-bfb5-f7417afb5191",
         "price": 68.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "12189b89-88c9-4eb7-8ec5-2ce6a4617ceb",
         "price": 98.01
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ba8bd248-3437-470d-b244-9b00c2beba97",
         "price": 16.01
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "aeabc326-d7c9-47cd-a463-65cac18f8c7e",
         "price": 99.29
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9daf6248-c46d-4331-9a9e-c0a0665e5cda",
         "price": 86.19
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b1930d09-1eb5-4373-abe9-fa671ffbc0e2",
         "price": 37.22
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e8e25003-9bf8-432a-81dd-fd6cdb11c422",
         "price": 91.91
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b57ce961-5754-4329-8181-85bfbf74fd24",
         "price": 45
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f9e95298-c989-442c-810a-774d35a5bbc6",
         "price": 14.15
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c0bd86b1-428b-421e-9fdb-c35b17975f82",
         "price": 19.4
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3e0c06a2-9268-436d-bb98-f9c88b030fb8",
         "price": 84.27
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3f5eda86-c053-404d-95e1-6ff3fd5480bd",
         "price": 12.3
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ad154b12-f148-4d09-922e-5e8aefd02373",
         "price": 42.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b0fbee5a-c394-4174-9184-b0a8c03621f5",
         "price": 83.78
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "74674438-9650-407f-a387-c55dac1e45d1",
         "price": 80.02
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a258597f-a232-4809-8033-b20a5b4eea5e",
         "price": 64.55
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c80b695f-b2c9-4e67-82a1-91d6b8255e65",
         "price": 79.12
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cba03408-b66d-4129-a26c-dbdac59a0766",
         "price": 33.13
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "470f4308-cb32-49c3-a373-b9522f219790",
         "price": 42.17
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6f5d39dc-4355-4cb8-862d-ddbb5fa26a29",
         "price": 73.59
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7da3a49e-74c6-45c4-ba21-c3ff8c84c2c7",
         "price": 23.02
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f7b71706-b701-43e0-8082-2bc7829d0404",
         "price": 80.15
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "52711f47-b540-4c7b-9592-5b441fc77465",
         "price": 52.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e7a7b37b-f897-4da2-8fee-24ab1f7337de",
         "price": 27.41
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8a55a39e-9f0e-40fb-9aa2-be431b74a7de",
         "price": 47.43
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "00ba573d-e51b-4ae0-b02c-c5cfef5122f2",
         "price": 67.38
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7a1fc56f-e64b-44dd-b2b6-bedfd1d3d776",
         "price": 76.14
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c0fd71c4-bca7-45b6-92b1-69486dad1297",
         "price": 26.43
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d84b133e-ef76-42a2-a885-4b12b3442d69",
         "price": 48.79
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b017fb66-7faa-4dad-81bb-5a9ca2634482",
         "price": 36.46
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "328f19fd-b055-4765-b0b9-e3526d44da29",
         "price": 11.83
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f63341e0-7604-49bb-9f06-7d2c34ca6a7b",
         "price": 89.14
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a7cbb797-444f-4971-9be4-11a5ed6fb975",
         "price": 34.44
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5d18a594-1b56-4d1b-a509-138b05342eba",
         "price": 97.59
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e083a326-7e63-45b2-a8eb-00b3b6fd0202",
         "price": 92.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d662e7aa-8901-493f-90cd-3325cb36bfa0",
         "price": 96.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cd3e87a7-eb4a-4f52-aa80-6c1c9fae2f0b",
         "price": 46.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "67ec4b38-887f-4067-aeb9-f141ae6843a5",
         "price": 22.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "018bb3df-6ac1-45ce-bd3b-befb79fca2b7",
         "price": 80.16
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d859dfc8-1cef-4d9b-ae06-ccae4840cd2d",
         "price": 31.92
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "62f1ae3f-0aab-4a0f-95ea-5b488acffa35",
         "price": 59.86
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "252a9ac2-fbea-4058-ac49-01e32b9b1123",
         "price": 91.61
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4c7f744f-fa62-42cc-8c4f-2c186a5a757c",
         "price": 86.74
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b1c694a6-8187-496c-8e49-f613a4abfc89",
         "price": 74.7
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bdc5850d-6d71-4c8c-a9cf-37d9c98a37a6",
         "price": 29.77
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4c691f7d-798c-428b-8330-9224e51c5319",
         "price": 98.45
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "fb4d9508-5909-4ec7-8a35-ef6d376adc94",
         "price": 49.2
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f4643738-8b84-43f2-b573-911595500330",
         "price": 24.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "590531b0-d5e0-427b-96aa-5f19aa050d61",
         "price": 39.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1f271986-fab7-47b6-ae9a-9700b8c5a0d9",
         "price": 23.62
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "297163f4-89f6-406c-b4fa-b34233f34a39",
         "price": 28.36
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "92abbb80-2a62-4d24-a863-3a3d6270b051",
         "price": 64.38
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9e4aa91b-7a92-498a-b562-e93645234de0",
         "price": 73.75
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9d3c1ca9-c2ba-48cc-b31a-531f7d2c7ce6",
         "price": 40.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6c9c79c5-74f0-4f97-bbb5-27c88791f1cc",
         "price": 87.06
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "85d5f79d-66d7-44b2-b986-6b6b4c6fa327",
         "price": 30.41
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8937988f-abb7-42c6-8868-0c7d218878e6",
         "price": 74.89
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d4a0417a-a989-4c2e-b394-b33e276b90ae",
         "price": 58.84
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f9e069b8-64ca-49ec-906e-c1108d409eef",
         "price": 18.13
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "94fff29a-bdf1-4fdd-9e8c-57fa517ffa9b",
         "price": 84.53
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1ac0d29e-a2a9-44a6-af4e-b156ef0379d3",
         "price": 97.48
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "51539d6b-8753-44f3-84a4-4a3a0ebe90c3",
         "price": 84.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "00040fa5-1cb4-439d-92f1-d541140b748f",
         "price": 14.52
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8f1ba953-945e-4160-adcc-effdce5f165d",
         "price": 66.27
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d1e62842-aca5-451c-b9c5-bd466acbcc2e",
         "price": 24.76
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0b0fb620-2257-40ab-b09b-3cabeba6464f",
         "price": 66.61
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7d5a456f-692b-4019-980a-d3fa9c12186d",
         "price": 79.72
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7486caf8-278b-40fe-b4bb-7b3489556f8b",
         "price": 81.88
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5e60440c-a378-4a39-848e-0fa324ef8f42",
         "price": 19.19
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "012237f4-aed3-4fd6-860a-d2fe5026aadb",
         "price": 19.2
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "afc9a8aa-caf2-48c2-bac0-c72f44fd6c82",
         "price": 77.18
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d6a2611b-f08a-45d8-9daa-8fd0c6eaf087",
         "price": 18.62
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5b6bce6d-f030-4561-a045-8d35ac83f455",
         "price": 93.6
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "8fd6386f-c69b-4321-919e-d9abc8a205c1",
         "price": 33.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7a66b7dd-b289-4182-ab06-e2180670f726",
         "price": 72.83
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e54a4339-43ef-43e8-ae1f-caddcc53433c",
         "price": 95.61
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f51c14ab-1b27-4810-8a6a-e91b620d9747",
         "price": 30.75
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "47b50dc1-93a8-4c73-8945-d4b1e6272cb5",
         "price": 22.26
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b60a5a7b-2efa-413b-8030-9435aca51073",
         "price": 27.4
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "0628a26a-48a6-44d0-80ed-fb87664067ff",
         "price": 44.17
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "49990b69-6cca-40b9-8f4f-a7d31ae6b1a1",
         "price": 56.17
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e18851de-8a99-448a-ad5b-e5f79b874996",
         "price": 62.66
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "dc53730a-8ee6-45a5-a00d-b613ca486f95",
         "price": 29.31
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e7381e6f-58b3-4170-ac03-7a2091d4a10a",
         "price": 54.62
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2b86d24b-fcb5-4ef5-9c2d-3135f7ced362",
         "price": 14.22
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "45c59186-cffd-4e12-a5a2-085a659418c3",
         "price": 47.47
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e8e763c5-9f02-450f-8ac9-29ee284eeac2",
         "price": 25.68
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "e5f79693-9024-4fbe-b5b3-5228e7d5a090",
         "price": 95.3
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "dcecf7e8-1cc7-4c9b-b806-940120c53201",
         "price": 42.88
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c60b175c-d128-44b0-9264-114129b5d0a5",
         "price": 67.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4a53c7aa-2be7-456f-9c30-10e1ddcf4d6f",
         "price": 71.33
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "31c0405d-adb3-4021-8c47-d1233e33bf70",
         "price": 69.51
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c2db16ff-425b-4005-a5a0-43f6d6449a06",
         "price": 48.37
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "54fe4c83-3334-4c67-9e30-37f43e02c5ac",
         "price": 72.88
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "bc79b2c1-7edc-43b2-8b48-fa0c8050e999",
         "price": 85.08
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "a4d308d6-4bc0-4f0f-b1e8-df69aeb64dfc",
         "price": 52.26
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "1b7984c6-6712-4e87-9a43-f1217598c4c7",
         "price": 22.23
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ef717e34-a35f-4dcc-b78b-d8a051ebd1f9",
         "price": 47.98
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cee3ed78-e209-4a2e-80db-d9c8123ce1d6",
         "price": 58.59
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "21e9d8ac-e43d-42eb-9703-a59992ac6329",
         "price": 55.24
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "235bffde-e1da-48af-86ac-698eb0a91d3d",
         "price": 18.37
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4ab1fce0-f6fa-4120-92e8-34852fed6e2d",
         "price": 28.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "64420c60-f88b-4571-98b4-9a74031fd989",
         "price": 19.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2df0d044-4fe5-4697-8462-88fe7aca8d09",
         "price": 28.66
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "13cfafef-d4e9-4705-ac64-d09339cf600b",
         "price": 26.55
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "f3219f48-03f1-4cef-84ae-9aa8f4899bc9",
         "price": 70.46
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d5ccfdc1-76ed-4de5-881b-48676178cdf2",
         "price": 42.02
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "dd36073c-7bcb-4254-8460-26f0695d7c62",
         "price": 27.78
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d5c7388e-baba-4ec2-8d2b-049432d29f32",
         "price": 67.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cc40de25-e7a8-4f32-ac09-3f15c64f8ec3",
         "price": 38.19
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7c51451e-b5d3-403c-a49d-b4a553db86dd",
         "price": 15.11
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "db63596e-9dd0-4931-8996-cdba349d8561",
         "price": 75.14
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "5f33df57-1bb6-4d51-8b54-3100674f748c",
         "price": 30.65
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "6641ab87-31af-4fe5-8ef5-ef61a34c37cd",
         "price": 57.79
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "78c3ce1c-3c03-4090-be20-7772eadd3fc1",
         "price": 21.01
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b8079ba5-627b-4472-b50c-d50bf7da9a74",
         "price": 34.95
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "4dcd674a-3393-4df1-a9a4-8fa45751282b",
         "price": 44.43
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "163319f5-c525-47fa-812d-c8f826a05e5c",
         "price": 66.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7aebcdf9-6a3e-4c59-b345-186e35df64e9",
         "price": 59.46
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "74c32db5-cb30-44d5-8c46-2c4f01e45755",
         "price": 29.92
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "26ede999-3176-4473-b40b-3aacd3c14c7a",
         "price": 30.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "25a09cf7-57ca-4968-ae95-32fe2a48934a",
         "price": 90.8
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "9a2a69fd-5834-4859-855d-4de68d2c6a13",
         "price": 50.73
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7533e896-adc2-481e-8cb8-febbd716a897",
         "price": 78.3
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "ac983912-d656-4d19-89fa-0ccaafaacb67",
         "price": 47.1
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "aa0fd697-a73d-475b-beb9-0b9f529ef67b",
         "price": 99.11
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2992082b-55e3-499c-8587-afc4a8734645",
         "price": 97.96
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "d45918ce-8843-47ff-8e0d-795b9f1f8419",
         "price": 42.49
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3cc4b5c1-f357-45f4-b02b-6b61eb5cf635",
         "price": 73.09
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "99c954a4-c62f-45a9-9fb8-c6a14110d2d8",
         "price": 44.06
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7ff89eb6-4116-4e42-8549-25e10bf663f0",
         "price": 61.07
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "24afb3a8-c1ed-4b6c-8cb5-0a47d2c6080c",
         "price": 96.44
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "024e01f6-b3d9-4857-bb36-44edba1ba404",
         "price": 86.86
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "64d3ce82-378d-42c3-ac3a-f4c90a9a7a45",
         "price": 79.43
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3fcbdeb5-221f-4fe6-9d2c-886441b8cd0f",
         "price": 24.03
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7f59392c-5c34-43ce-bbdd-b9d1ebecd0a1",
         "price": 67.25
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "3ee3b0db-c865-4627-82ee-d1b95993475f",
         "price": 15.33
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "317d2464-6706-4ca1-8234-9c9476418e76",
         "price": 13.65
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "cd50bb4b-7482-4900-bf51-b0c59b248736",
         "price": 53.76
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "b7c13707-6f23-486b-a3f2-dfc0a0b41337",
         "price": 99.78
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "7970275b-29e4-4319-834c-0031dea24b0c",
         "price": 97.87
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "2738e734-21fa-4ae3-b1ab-666ccb6c1bf0",
         "price": 45.2
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentAccepted",
+      "event": "request_finished",
       "body": {
         "token": "c357bdea-4bfe-45f9-8249-fc1a34983402",
         "price": 73.24
+      },
+      "message": {
+        "event": "PaymentAccepted"
       }
     }
   ]

--- a/data/success/payment-submitted.json
+++ b/data/success/payment-submitted.json
@@ -1,4002 +1,5502 @@
 [
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "59885993-dce5-4472-972d-0a54b3f61595",
         "price": 33.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "eb742477-f64c-4baf-bad4-70ce7bd7b5e7",
         "price": 21.62
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fc6c0231-1979-476b-8530-826d877c02ed",
         "price": 79.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a660143a-594a-4cf2-938d-fa6695abad60",
         "price": 60.71
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0286eb94-48f6-4dc1-9d16-8472e3f01046",
         "price": 75.96
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0e5b3a5a-7a55-4807-8762-f567305c5061",
         "price": 23.2
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f7682318-f96f-452e-adc7-12502d624a65",
         "price": 81.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "39aa2702-3403-4e6a-8548-212cfc625d98",
         "price": 69.66
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8ee3533c-e73d-427e-bde4-8a413f872581",
         "price": 89.67
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2f8536d1-a97e-4d27-8c38-0ad100bad4f4",
         "price": 38.82
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "aa44d501-46bb-4ba7-a8d5-107a34bff40b",
         "price": 19.79
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "13ecf4f6-3fdd-4038-a61e-4dedee655695",
         "price": 22.59
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0254199c-5551-40c4-bd79-35caeabd70fc",
         "price": 19.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c39e83c2-7d30-4124-b21b-693d631ff08f",
         "price": 73.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cbf592bf-7aca-4415-9b7f-a2004f033aef",
         "price": 58.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "248089e1-d8e6-4446-a123-5c9a962801b0",
         "price": 47.25
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "33eebc49-24e9-43ed-8804-38314ce59f9d",
         "price": 95.58
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b2b4c090-6c34-43d5-a5c3-a2ccb6632fa3",
         "price": 50.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d83ddab4-2d8c-4214-8589-885bed4de4fe",
         "price": 36.6
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "30a6cf5c-c374-4efd-9e02-42aacc1c2a71",
         "price": 38.13
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bcb2d8df-906d-4efb-a01b-d5fb656459eb",
         "price": 79.27
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "76648f0d-3b65-4ff3-98bb-ef9b57985bc2",
         "price": 50.98
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "00322b1b-60b8-44de-9f43-db6c286a36e6",
         "price": 44.06
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "866efad0-0041-4fea-bc11-93c09e30456d",
         "price": 39.08
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "316d845d-0152-4f7c-b131-2b4644db7790",
         "price": 91.7
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5179888d-b2ac-41a0-9f94-6567115cdf1a",
         "price": 97.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c21c069d-6244-4986-8d41-7410058dff4f",
         "price": 63.82
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b2e5a610-9c63-4740-99bf-4cd00927775e",
         "price": 38.14
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d1db26d1-292e-4c6d-983b-fcbbaf5906ef",
         "price": 50.53
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "64061140-f9af-4fbe-be9b-c7592fc61ea1",
         "price": 49.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ded9aacb-7469-400f-a962-4dc25acc9716",
         "price": 55.92
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7b56efff-2b18-4be8-bd06-05b3ed706319",
         "price": 84.85
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3fc671ce-685a-4eb0-a704-4bb8a8b51a1d",
         "price": 45.68
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d8363dd6-e6ed-4d36-9c2e-be1dce2bd9a8",
         "price": 86.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7903c39e-8974-47a1-ac70-31ae370419aa",
         "price": 49.91
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "65c05e35-120c-4e05-a09c-594b6ef248d3",
         "price": 37.79
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b07ff8be-3c39-4ec5-a019-e1e5351e5bbd",
         "price": 89.68
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f2974edb-d731-49c3-a792-c2ccf011d82e",
         "price": 85.03
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "166d20d6-fafc-48e5-b3df-04f642cf2997",
         "price": 11.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0221e0a2-95cd-4617-ad18-3e64e0aceee6",
         "price": 58.56
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ee0c2584-3b51-4dfb-bc96-bac559b413c8",
         "price": 35.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b4999810-5bd1-4160-aa04-667ab6790de1",
         "price": 15.66
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "377dc7f7-ebc2-40e1-8aa1-e6a82bf67f8d",
         "price": 51.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fb0538e9-7e1d-45b5-a966-eee29b05af02",
         "price": 28.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "55c8461a-f846-4471-8c89-d26f464ef2f2",
         "price": 13.29
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a0423a44-4081-49b3-bf36-6dbb11568064",
         "price": 42.42
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "74982716-9081-4467-89c4-4beb2dee24f2",
         "price": 42.27
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "271ddb41-91db-4036-9376-4719aac5ba8a",
         "price": 22.41
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b85f49b7-174b-493d-a193-7a1acb7bdfc4",
         "price": 63.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "076772f6-9ea2-4e57-99a1-3dc8e821ae39",
         "price": 15.82
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "95f364be-82a4-4344-b3fb-bfef81d6edb3",
         "price": 69.11
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "33aa6bfb-c73c-489c-b6ef-a61734c6ddc5",
         "price": 23.03
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7eca59cc-a9b5-45c9-95f1-348d77516178",
         "price": 20.3
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bc87666b-4939-4804-ad58-dfe4a4c31b85",
         "price": 40.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "64131265-0145-4783-a1f3-66a646cd924e",
         "price": 41.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "39d3ecab-a799-44d0-86bc-34e16f78b64e",
         "price": 37.32
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fc3c14ba-b343-47aa-9049-a1bb38214c56",
         "price": 19.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "91af2220-e703-48b4-918a-15d805af0551",
         "price": 27.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8d8a4f6a-588b-4f73-9062-0f2b6f4c9f16",
         "price": 65.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7c504b32-fcd5-4b93-b2a0-c71a85984a05",
         "price": 73.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "81301fcf-a5ee-4d39-aa49-77e5018eec63",
         "price": 90.36
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ff3c7e7f-6735-45c6-ba99-d261df2915e6",
         "price": 52.34
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0b2128ee-f526-42e1-93b8-730892dfcf64",
         "price": 33.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "206665fc-9231-4d75-ab63-1d14989e1208",
         "price": 29.51
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2b49c20d-65ad-469a-8f64-2b83fc4aeb7d",
         "price": 99.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8a24c5b7-e616-4eb8-9836-7831899e4bd0",
         "price": 50.19
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b722b948-ca0b-4572-872a-27b7e93ac4b8",
         "price": 46.03
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b7794666-6c13-4c87-a6df-f81a65c14693",
         "price": 65.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d798ae6a-1d05-4cd9-a7f2-4d83ec882d6a",
         "price": 21.15
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "116b2daa-08bd-48fc-8805-f852ba660206",
         "price": 35.14
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "37c14684-a6c1-44c6-9d57-24d13aafacd0",
         "price": 26.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bfb998d4-fc86-4998-9257-1938dee587b4",
         "price": 77.87
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "865d2c64-40f3-4850-aca1-e6f60f91833a",
         "price": 82.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6777630d-1604-440d-8f07-be0915bb976a",
         "price": 36.22
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4cbea6e8-7679-43af-8597-f51995c0bbed",
         "price": 60.27
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "08cfd9e5-5d63-4a71-b3c4-4b64e320062e",
         "price": 39.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "01ed580b-b0d0-4a31-a85c-28b27093d491",
         "price": 43.62
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "beee91dd-6574-4746-9314-301b0dd96fbf",
         "price": 39.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "135bd59c-4763-4222-be8d-b11e0dcad30c",
         "price": 21.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f91902e8-7561-423e-9837-389efcbadc17",
         "price": 27.17
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "36e09f44-9713-4b96-8249-e26d00e69cfb",
         "price": 65.69
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ce8392bf-58ad-4722-b3c3-46258d8c65f0",
         "price": 98.69
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "345dc61e-6e79-4b1e-83e2-46be8cb1783b",
         "price": 76.15
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1eadaca2-5fee-4d08-ab55-fbc12f6edf44",
         "price": 18.71
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "721666f9-b45f-4e75-b639-f740fc85709e",
         "price": 50.3
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d557d841-4a30-4a95-bf1c-3c96294eb566",
         "price": 69.37
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d9730e15-4a62-4c0b-9276-04ce587a9e45",
         "price": 36.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "75b19d98-824d-462e-8a10-81a9d0d1022f",
         "price": 38.43
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8bcf98ea-1bad-4d7f-a595-3379c5aa2b91",
         "price": 98.47
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "06ac2f72-8603-45c8-8313-a04f2b54d8f5",
         "price": 71.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "397c63c9-3759-4dac-8cbd-238f257ec6c8",
         "price": 86.6
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e17a4cde-b510-4a39-97d8-aed4f9f4d3ba",
         "price": 25.08
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3dcc6466-de8d-4995-89a6-14421f3aac6d",
         "price": 49.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9589bd86-6e31-4e39-ae3d-503142a0ce63",
         "price": 44.43
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "044d607f-6312-4986-8726-2b8b269a98fe",
         "price": 87.03
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7acb2c23-35ce-427e-a31b-138792efa99b",
         "price": 57.95
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e039f57c-b6b8-417a-af5d-9a17de9f9b25",
         "price": 29.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "abd137f9-8e34-43a2-84d9-74f0a3de19f4",
         "price": 79.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "08e4b20f-cd0f-4338-8747-ca6df78e27bd",
         "price": 14.24
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bc740267-1fdc-43c9-a497-0402476844e5",
         "price": 94.77
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5a9f2720-a4c4-4e58-8b00-37e8c5c93c57",
         "price": 24.33
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "30905148-b5e6-4899-a492-457d4d46ae78",
         "price": 92.8
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "999e359b-c334-4d64-851b-548941295202",
         "price": 18.67
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5b97d9b4-8c24-47b4-b353-3b34fb114cda",
         "price": 16.07
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a0e948dc-7652-4d05-8522-e5cc4bd87c5a",
         "price": 61.74
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e2c14438-d4a3-4ea7-bbcb-23b4fa950301",
         "price": 86.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "70cc077a-0404-4a45-a166-242e7e56943b",
         "price": 68.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8f2f1fa8-188e-4450-88da-af27b46b7522",
         "price": 59.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "55ebdd29-d930-4e3a-8a13-cc8a213a1a17",
         "price": 76.03
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f0802ea1-3c5c-4f6a-aa26-41ea69481413",
         "price": 47.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4effc8a0-a76d-436f-8dc3-da3d19d19424",
         "price": 78.3
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ea2c2cb5-29bf-4601-bfcb-f9a1b236c70a",
         "price": 59.71
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4aa9d852-e381-495a-8938-a4f19009ae84",
         "price": 58.73
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d7d7eefa-6967-4b88-af64-075e86c3e002",
         "price": 96.45
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7b35bdfb-fd48-49d5-9cac-a361187962db",
         "price": 67.3
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9dd0ff36-bddd-4b6f-bc4a-2aaf8d59be17",
         "price": 33.36
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ee180d7c-53cd-400d-807e-02b46f60294c",
         "price": 55.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1e9d166a-2673-4c19-9131-801ca8a5a1e4",
         "price": 35.34
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "99c1c2bc-f905-41aa-8a98-f9c4f4e81629",
         "price": 92.55
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3143d8bb-b4de-4c1a-affb-11cc5f9aed39",
         "price": 70.05
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "120bfeaa-82fd-4f35-853b-8bf793a39416",
         "price": 15.56
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c01f9401-caec-4947-93dd-37bbe8337609",
         "price": 75.96
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b9b72596-16a6-4398-830a-0cb590cb5708",
         "price": 40.38
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "42bf1c27-f74d-47a2-a77c-fc0fdda926bc",
         "price": 72.8
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9b6808d4-6bb8-4c9d-a892-6baa02e6a941",
         "price": 20.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5013a63b-60c2-48b1-8c5b-2a463cc7fd06",
         "price": 71.4
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "18c6161a-c907-46a4-b7e4-3e2c96e8d492",
         "price": 37.48
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3e251d03-82a2-4643-96ce-126c67301005",
         "price": 58.28
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "016c6aa1-24e3-46f3-907a-414e18543b24",
         "price": 82.61
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0132d705-804f-4bb9-abbe-d4be3ba02a3f",
         "price": 33.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8b1f8b22-e3a1-4881-8218-a53bf53a893b",
         "price": 37.15
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7715a3cf-ae6a-4e21-9464-20a69b6bf30d",
         "price": 98.57
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a7d161b4-3d2b-4a0c-aa52-e4f876087e05",
         "price": 70.32
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8ffd8346-07a4-4cbe-a48c-9218f81752cb",
         "price": 22.36
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "20b293bf-38aa-4e65-a2d8-6c6db14876e6",
         "price": 29.19
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6f257958-6af2-4b5c-b098-bf830380eaf0",
         "price": 20.16
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a6d147c1-0569-421c-a5c5-ad9a8c159505",
         "price": 16.7
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a46b347b-0e23-4f57-8856-c9cf395a3407",
         "price": 53.77
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3144853f-50bf-4515-81c2-ded3c9c7dd94",
         "price": 72.51
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1ba46133-c8b8-4ac2-a8a2-4d43bd945f7e",
         "price": 70.47
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ecfb4b58-7a55-4861-9d1c-5fd0636dacca",
         "price": 89.48
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "207e5d8c-0a3e-4493-b81d-16b459c512d7",
         "price": 87.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "749571e4-f9a2-41c0-9fa7-989b72983d22",
         "price": 43.58
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "61dc5593-6bde-458e-be72-c1cc33e9d4d3",
         "price": 29.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f44c300b-04d6-423a-b7e9-7614becde94f",
         "price": 25.86
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f07f00b2-d9e8-4e25-880f-380627ee2ba0",
         "price": 17.06
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "be5c0b2d-2e63-4835-b27c-ff5fce2e9bb6",
         "price": 37.72
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6455b915-2944-4e5b-be94-e15a9c789209",
         "price": 29.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1dd794fd-f4da-430e-95d7-273637cadb1d",
         "price": 65.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "efcee1be-8f37-42f1-93a7-41841ac33cb2",
         "price": 64.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1bf02c7a-4524-410b-b38b-33e039e78c3a",
         "price": 83.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1591c068-f369-4897-8c41-97660b743e13",
         "price": 83.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8287df26-a214-4fbc-9713-e8154abb4adc",
         "price": 13.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f7674998-a634-4ecf-96a8-a10e92fbbb36",
         "price": 60.1
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a642e926-567d-4bca-b17b-e2a90da75213",
         "price": 67.66
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6a53fd3f-4cc4-465b-b5fd-7857cfda2a7b",
         "price": 29.71
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "caf47e73-e529-4d37-93e8-0fe441a4038e",
         "price": 68.48
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a9147415-7e48-4f84-82e8-781c4b59d85b",
         "price": 66.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1a83bc4a-94bd-46af-a670-c9f58b987fbe",
         "price": 43.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "20097379-4754-49ce-bdae-1f65f2e5a37b",
         "price": 64.76
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "acae5bed-5c32-4fe6-b263-9db03f451a8d",
         "price": 93.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e92ad711-e272-4c95-8906-b4b73134140f",
         "price": 91.2
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1836eaa3-304b-45e8-9c5e-1df86bb04e36",
         "price": 36.03
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1f123922-bad7-46f2-9362-003b195c3a8e",
         "price": 10.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2664e038-3ceb-4ca7-8478-2c0bb599b4ef",
         "price": 66.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e659d105-43eb-44be-b48e-aa753785a172",
         "price": 65.78
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3054903a-5340-4ffc-bada-4f5a058eb957",
         "price": 39.86
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3487bbc4-5a3d-442a-a238-493ee8d789c1",
         "price": 35.95
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "990776f0-2ec6-4980-87cd-5aba789951a6",
         "price": 55.73
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "31fda169-662b-41cc-99db-054f7bcd41ec",
         "price": 81.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3c14cbc7-a370-4fbc-8fc6-fbe100966143",
         "price": 19.85
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "85fc3ceb-6753-4f2f-baef-ce62a95b3179",
         "price": 25.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a2edef9a-7ac5-46a2-8a48-3231c37bccab",
         "price": 61.41
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1ebaef90-f142-4acb-9760-dcebad576a6e",
         "price": 60.55
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1ef4d3db-a87f-4c50-a3ab-cd22d1baabae",
         "price": 84.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d9324d70-e5d1-446f-b53e-c3b0f50309c2",
         "price": 94.07
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "66080a07-9f99-4d0e-b0cc-709fff941a52",
         "price": 73.36
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b1ebea44-d59e-4a5a-b16d-afd305551eb1",
         "price": 54.69
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a2024ddb-c1f3-4bda-8e52-3e358dda17e8",
         "price": 93.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fc08aff5-a01b-421b-8c9c-3b794b23ac3b",
         "price": 79.38
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8b5d484f-653f-4e69-ac92-e727bcb9a915",
         "price": 95.36
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "47476613-8498-45c6-bd33-93feb81ddd24",
         "price": 47.05
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "280ac705-8da9-4c23-8ade-61d526fbb1fc",
         "price": 55.7
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "03c50248-4501-4f96-a9ca-f1fb56ee859c",
         "price": 26.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "eef5f314-53fc-401e-ac92-8323c69a28fe",
         "price": 20.64
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d77f8efd-fc5c-47e5-8482-8035e94f4ee7",
         "price": 23.07
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5ba29d12-3879-45cd-8f86-c0e72f21c2c9",
         "price": 70.92
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "20fc7649-74ec-4ca0-9427-40cfea97bbc6",
         "price": 13.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cab13553-1021-44cd-a30f-d938e13b2526",
         "price": 53.67
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d6704d71-33f5-4684-b31f-9d2d2cc08492",
         "price": 31.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b3cf211a-85ef-4eb2-9ff0-62c284bc1e97",
         "price": 59.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e93e0e7e-ac03-4e0b-8d82-6b7c434a67ba",
         "price": 66.61
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "eb33b8e2-b047-4ea6-87ee-ceeea2db7a07",
         "price": 19.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e9c2ef4e-9d52-4135-9ccd-6f67ce0a3970",
         "price": 41.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "33c3e1e7-39dd-4205-a549-d6837cc99991",
         "price": 73.87
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "227dc901-b299-4208-acf8-11c92d029c64",
         "price": 77.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "87552603-6ef8-451e-8fa4-6ab5143131ce",
         "price": 67.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "06afedca-f5cf-41e2-83b0-4d485e8c66a2",
         "price": 19.79
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c7f54a04-0677-4bd2-9716-2321c374b384",
         "price": 99.1
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "014c537e-8286-498e-a02e-9c50fcc0ba66",
         "price": 16.62
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3d3d6f19-f971-4d33-85fd-a64c92fd7d36",
         "price": 78.86
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d40d7eec-0dd2-4eee-9b1b-5e19b7811b14",
         "price": 67.64
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8ad8a41c-f119-4947-923c-a3ebf72a0c7d",
         "price": 75.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "262face9-7b61-4be6-868c-a0beeea91db4",
         "price": 26.34
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "837a2c2d-6585-47eb-84ff-190e82c4c0bc",
         "price": 64.05
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1e77b4c1-e2c8-4de4-a02f-499b7ee24b97",
         "price": 32.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9f7fa14c-f679-4816-a8a4-60f7615c83e2",
         "price": 28.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2e4c39e6-bf9b-40d0-b478-a2e3eec2eb20",
         "price": 74.93
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "71ac75a1-9fb0-40d3-976c-e6b69d7e3bd8",
         "price": 37.32
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c6261ee2-7540-4b06-817b-39fe8520ee08",
         "price": 53.44
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7e0f709a-7fce-4f68-854a-314e7837b23a",
         "price": 58.57
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3c414500-f525-4788-a98f-2c315b05e752",
         "price": 71.18
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ac50e8ef-4828-4d60-9efb-d8849e3b2695",
         "price": 48.52
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f262a1a6-40de-4bed-aded-7d48bfd6370f",
         "price": 56.98
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e678a9ce-c1df-4b85-8c91-7919921de612",
         "price": 45.61
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2af41010-47cc-4048-8ef5-3695b1e56670",
         "price": 29.5
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f6c1755b-1cf9-40bb-b57e-9463731c363c",
         "price": 13.19
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "58e07738-d9d0-4c9b-be33-304fabc287f7",
         "price": 66.4
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d5bf2313-01d8-469d-a249-641740eeeafc",
         "price": 99.2
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6c7c2a3e-3794-4ba6-813d-f80469231493",
         "price": 23.19
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6ebd9903-9abf-4434-a9cf-711a18a48ea6",
         "price": 94.51
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "14d8370c-c9bc-4ebb-84b6-86b9d7fb5ed2",
         "price": 24.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fb2f1a44-c3be-4a4a-90ad-9405441cb09d",
         "price": 44.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cb0972e9-72c8-4483-90a7-e436836d58d1",
         "price": 91.21
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "48a8a3c8-450d-48c3-8bd3-c493d798440c",
         "price": 58.6
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0a56a1c4-dfd8-4a5e-8955-b6e37e6aedf0",
         "price": 19.27
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9f97b8b9-f78e-4c59-9fc4-d33829b1399a",
         "price": 16.72
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2600eb6b-a6cc-4aef-833e-25e1cb4598bc",
         "price": 23.93
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ada75936-f6dd-4373-9a4b-d9bead0fdab2",
         "price": 57.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d381f8fc-52f7-499e-9226-5d7bd89b123f",
         "price": 99.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "09cf1b60-1036-46b9-bac1-b72865c3acaf",
         "price": 65.64
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5dce35c2-bd40-4079-82e8-2f37bc61041e",
         "price": 47.08
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5b983034-922d-478c-aea7-872d16b6ae47",
         "price": 22.33
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "21f1458e-a9ec-49e0-8d70-29fe73dbb451",
         "price": 19.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ad3bce1a-7002-4eb5-8625-7d28d6ac1583",
         "price": 46.91
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "41813b4e-f4b3-4f61-867a-4a8f115dfff7",
         "price": 32.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "167fd079-63d5-43d2-a6aa-1e31f454f79f",
         "price": 59.18
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5e70a108-cb8b-42a4-8d62-1aa3e27a42b7",
         "price": 46.53
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c4ecf60f-9499-40e6-b5d2-4db8a0d2c644",
         "price": 83.24
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0359122e-bee9-4611-bd1a-e142ca5c75fa",
         "price": 14.01
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "570fe93b-be8e-4e51-888b-6388c39389bf",
         "price": 18.1
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "565705df-d60e-4f50-8968-2c4f7eb9b361",
         "price": 99.74
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "950bef5c-75f2-404c-bde4-0a52ad6c9b04",
         "price": 10.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d8d8a20b-3429-4ece-8f92-3a0b8305a293",
         "price": 32.19
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "84a1a4ea-f2ef-43b8-b950-9cc03a1507a6",
         "price": 88.57
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "af21c54f-90eb-47bd-a0ec-aa1553b6709e",
         "price": 91.44
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cd756c8e-9cdd-46b5-8b3f-99aee582c52c",
         "price": 51.1
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f7bb7549-cdfe-4a98-9f27-2790d3f5c188",
         "price": 48.13
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c54f2d13-15a4-457b-bf26-629958713ab4",
         "price": 95.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3bf43b2a-6527-437e-9d38-2426a143521e",
         "price": 12.44
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "40dcbda3-92fd-49d3-bf5c-48e59e3cdd8a",
         "price": 65.04
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "aaf1df06-499d-4bbe-a79b-ca0ba649a38b",
         "price": 27.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f0caebb4-4169-486f-92ad-e9a4fc2cd20b",
         "price": 97.66
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ad3b1991-d863-45cf-8a88-ffaf8ec30a4d",
         "price": 22.8
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c9d5feef-064c-4e1a-b3ac-97d01b4260ea",
         "price": 21.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4e786fd1-006c-4dd8-b96c-f46899346d45",
         "price": 42.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4d1a2fc6-297b-4118-b549-4348ae3c9568",
         "price": 63.48
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fd8c7cc6-8047-488b-b10d-0183e0e42abf",
         "price": 94.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c456d8e2-a3cb-4e1a-82c9-5e1dd01ffd3a",
         "price": 61.21
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c95d677c-c416-4d67-b6a1-f9d77db33dcc",
         "price": 12.96
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fc922940-6c65-4f6a-a063-e5588ecaa631",
         "price": 84.51
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0925ef94-317f-4727-8a35-7d9418233fb4",
         "price": 56.21
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "373c0b3c-6581-4703-946b-be93d0046438",
         "price": 59.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "14525cf7-056c-4cd6-b18d-55584f62809b",
         "price": 18
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ba77d96e-04dd-4c54-ba87-624bb060a78b",
         "price": 97.4
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4f0767f8-31fe-48e9-a96f-1bf7b061c9b9",
         "price": 26.62
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b7d9524c-c0d8-4c58-96bd-e05f7774b038",
         "price": 71.82
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cc4ecc0f-6430-48d5-9294-08e2b20a357c",
         "price": 92.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1fabe723-de4a-42e3-a6a1-dcbf9ce05429",
         "price": 98.82
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cbfddf7c-56cd-4e35-a08f-b70d9b786feb",
         "price": 65.17
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "caad866b-e9dd-464b-84d0-c51a39e831af",
         "price": 95.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e7482a4b-7461-478b-a31a-4044f134b7a3",
         "price": 27.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "96fec1b1-791e-42d7-b086-21035b13d120",
         "price": 99.73
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fe4105c1-82f8-4037-b88b-50fc9756a475",
         "price": 23.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "afcc3cb7-ab65-4de8-9f70-a586e61d5b0c",
         "price": 39.28
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ed206504-d796-4cc1-a271-cc4e73abc652",
         "price": 41.93
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bf8314a7-212d-4237-8af3-fdd6c46f1efa",
         "price": 51.83
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ea402b22-d864-4849-a478-efe54569c2d3",
         "price": 43.11
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "475222ac-230a-4f73-99b8-5cd366e666f7",
         "price": 33.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "45f9f037-8b99-4e63-a2c3-08ac343fb992",
         "price": 62.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bf3cb627-5b8b-401f-9607-292f58d85b82",
         "price": 53.1
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cc23312e-9e48-4662-b933-72dfcfd02c85",
         "price": 54.43
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c3eaeb11-65ce-4687-8572-39d7809b04a4",
         "price": 20.38
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f420919f-b5c5-44e6-8185-8c3b024cc8f9",
         "price": 24.72
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5d94f6fb-ad55-4058-8b1c-b435b7df749a",
         "price": 13.59
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bdc8df10-dce0-40eb-aadc-0f978783806c",
         "price": 89.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d12f5ebd-cf7e-4e03-9db3-e48a63616fed",
         "price": 62.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d6d0e556-b73c-4a01-b283-089b2e3705a1",
         "price": 63.57
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c0074f03-ea77-4df6-8bd4-d3cf8a6d0893",
         "price": 67.29
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1d4f5074-5d17-4bd3-a0f0-7de549c6a2a6",
         "price": 89.71
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "226092ab-5859-4fce-986c-e2c1f7621f1f",
         "price": 41.45
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9b2b59b2-2496-48e8-8199-78e04c0fe01c",
         "price": 43.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ebd6a13c-c52f-4fb7-a6d4-c820d47e1fc1",
         "price": 59.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a510f559-a52a-4fa8-ad1d-79ddb1c61e47",
         "price": 88.7
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b0cf8851-5d27-454a-a8a7-0d9fb96cea1e",
         "price": 34.11
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fa04707b-2753-496d-9a40-fa71aaf83cd5",
         "price": 14.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ab1efb9e-cd17-415b-90d1-42edfdd0539d",
         "price": 67.54
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "aaa00e08-82c9-4621-bb8d-29e578be667b",
         "price": 76.16
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f9a1993a-b5df-4266-8562-c9cd419b021a",
         "price": 79.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b7d46953-57af-4c0e-9089-22f6e7f96470",
         "price": 18.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ca6c5b8c-958f-4ab6-a03d-d4b471b5e73d",
         "price": 22.76
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3c03cd39-1b22-402b-a9c1-0ff69f02db5c",
         "price": 25.67
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cbb35667-cb4b-4a65-b2fb-8dc76c1c78a7",
         "price": 80.77
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3c66b326-6362-477f-8e3e-54a8d082f6f5",
         "price": 81.38
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7d8b0e1d-5e4d-4297-988f-9c908a9998f5",
         "price": 39.36
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b044201f-5f33-4b2f-ae4c-9522a359bf4d",
         "price": 31.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9d85f532-c21d-4409-8778-aaeb7061ab2b",
         "price": 76.07
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2d03dfbb-8334-45d4-b7cf-f532f28fb023",
         "price": 22.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e3c9e9ff-de4a-414d-bee0-ca3bde32ab79",
         "price": 98.11
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "35ba41ba-2b77-4488-92e4-6ad278f068fb",
         "price": 50.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "26b51c73-b171-4bf1-a79c-88cc2b84467c",
         "price": 84.92
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "21f62636-66a6-494b-ae5a-33029eea733b",
         "price": 16.81
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6d82e9a8-7967-4e9f-87e1-903e2334ea9b",
         "price": 46.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9f15c431-c033-4e3a-b67d-a2c870506e1f",
         "price": 25.22
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "19be94f0-1a8b-4509-8b58-01740d37d910",
         "price": 94.7
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bcf20da4-37df-4251-9930-a48040eb7bf3",
         "price": 73.01
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7156c55e-122d-44a8-923a-85fd07014ee1",
         "price": 50.86
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cc53cc28-020e-4814-ab6f-157ef5aae7db",
         "price": 11.41
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "41c3cdf2-574e-4dd3-a5ec-321110eb3721",
         "price": 92.35
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7ec7aa3f-dc41-4a4f-8646-1f13f489a417",
         "price": 22.1
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d59c8272-19dd-4c47-aef1-53425f9019a6",
         "price": 28.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e6781c55-3f93-40f2-a601-58928edc9d8d",
         "price": 19.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "88498836-8c78-4e9d-932c-452fd86bc840",
         "price": 64.52
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cb5fdc4d-1b2c-4d83-800e-c5c41dce8aa2",
         "price": 66.03
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9cd60bc4-0583-4f58-b7d6-9cd5c5c5cf39",
         "price": 13.29
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1d1502fd-498e-4dc9-b3bd-15f849ccda8d",
         "price": 41.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "319a30e4-1e33-4c52-8b54-e8ce139e915b",
         "price": 81.87
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "61a56193-bc55-43ad-8bb6-c670abfd436f",
         "price": 97.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "64f81330-c315-4fd0-8b68-5e0ddfac9d9f",
         "price": 50.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b39e1720-1823-43ae-a69e-3879c6dd296e",
         "price": 46.01
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0812d472-e76d-4f7e-a64d-a034a0971896",
         "price": 43.48
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3a13affd-4cbd-4b8f-a85d-8107af29f124",
         "price": 50.77
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cbc32983-2b1e-4e02-98a7-420217525a49",
         "price": 60.64
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ea9aa02c-290f-444b-9144-a9e3893344ef",
         "price": 29.82
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "521a56a2-8df3-4027-8341-c82fe8c8eb60",
         "price": 58.62
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "eb6d6434-951e-4eda-9726-cc1438ece1e2",
         "price": 29.74
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3d72b45c-29bb-41a4-a4c4-7ab7e4a6618c",
         "price": 54.9
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "83248c5c-6629-44cf-b68c-817364a4e232",
         "price": 79.13
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c7ef14a5-0097-40bd-83de-2f3134558d0a",
         "price": 69.6
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a19e9445-b591-4f80-8ded-3b7964b47e63",
         "price": 15.83
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "073dfe25-e318-4d69-837a-69c453c87e13",
         "price": 12.49
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6cdf5d12-21a1-47da-8ec7-341564f2c697",
         "price": 35.37
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "32ca4fe7-2a9f-4eb9-965e-ecbcbe75f63f",
         "price": 25.44
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "da8fa2ad-32ec-4e50-be2c-ca794de77ec1",
         "price": 95.38
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a824e0e0-b4f9-4dde-9c26-53a3d93ed982",
         "price": 36.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a76fcbcb-f3fb-4335-b0c1-0c58aff9f734",
         "price": 50.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f00cba90-f9a7-4d7f-8f61-5ee2dda8001d",
         "price": 94.08
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ed0aafb6-f66c-4139-be54-b4a2ff288c15",
         "price": 64.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f2b81fe5-645a-4e40-98fa-ad0788d8d570",
         "price": 60.64
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a474db73-433e-40ea-8171-7d840c12d0db",
         "price": 27.3
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a3d84a0e-b745-4457-ac4b-12dd32628c0c",
         "price": 28.08
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "acf7eabf-9a4b-451a-8171-fc883236a8f3",
         "price": 78.8
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a647fa64-0328-4a5f-84c5-90784f2eb01a",
         "price": 80.45
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3002df6a-9c78-47df-8c07-bbaa3b5da05e",
         "price": 19.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6de425e1-5c59-43a4-9de1-783a62a2fe89",
         "price": 37.62
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0329578d-d576-4887-8173-7d1a8446966c",
         "price": 83.5
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ef1a84fe-eda2-4541-9ce9-7a6703b77cbd",
         "price": 70.4
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3cd0d4f4-6931-4b4b-b477-0ab1a7056eb4",
         "price": 54.79
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "37f4be27-76d3-41fc-a786-a0ac9e95ad1b",
         "price": 58.21
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7e528def-55e4-4846-bf4e-baf32b8ed21c",
         "price": 84.08
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6a6dd3aa-fac3-43b5-80a9-111cec3a076f",
         "price": 32.72
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "23888b68-1555-42f9-b4ec-5536c89bbdbc",
         "price": 66.57
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "27807607-b426-433f-b74f-526cdf504c84",
         "price": 60.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b8a3768e-a1e8-49b2-a422-2d6f41520214",
         "price": 89.32
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9b24ba90-5cfc-4a58-ab15-815039909e15",
         "price": 90.25
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7e972649-ae13-4411-be43-974f3a77f374",
         "price": 72.25
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f0490d01-f2f2-4eac-9626-eb384a88000d",
         "price": 31.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ec55b8b6-d5f3-4629-85c5-8b98d1ef2b56",
         "price": 78.72
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7421d794-01e4-42ed-976d-c47b9b922fce",
         "price": 62.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4020e294-c27b-48e0-94e9-9f07fa37255d",
         "price": 80.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8d4bb3a2-3f70-4d11-9632-deafa91c3486",
         "price": 40.1
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c8e2c8cd-cc14-4d84-afce-5babd37c8186",
         "price": 65.61
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d65e5dc4-86fc-4793-8267-2b6e24152d59",
         "price": 96.28
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4eecf819-b773-4259-ac91-3f2b1d1eaae9",
         "price": 23.36
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8e9d8c4a-ef39-422f-b512-e2e6f98f9dc0",
         "price": 52.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "cca8e74f-d2df-4408-a54c-02c946e24bf3",
         "price": 81.8
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1a701b25-2a02-4571-b73e-200e96a36eb2",
         "price": 50.49
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0f43658d-7df5-4319-b389-45e262f3b761",
         "price": 93.16
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "fb3adc4e-67d6-4901-baa6-e2544874611f",
         "price": 19.58
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8eb2a4a1-80b4-4bcf-aedb-169969a28c2c",
         "price": 93.04
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e6becbf9-df43-4fa1-a9d7-2349df1266fb",
         "price": 49.68
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "db85ad79-8544-4113-b57c-fe61787962e7",
         "price": 98.11
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2774da19-4daa-462b-956d-5b41da345ee9",
         "price": 67.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9af0c522-f51e-4ff5-8d8a-0a731d48b9ed",
         "price": 26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bc422251-3763-452f-abb4-5bb880f32dcb",
         "price": 85.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3f16fc37-ed77-47f3-bcc9-c00f7a117757",
         "price": 42.34
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "540fb48a-2674-48a1-be73-a3a3be8bae2c",
         "price": 12.58
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e0802c17-586f-4926-ac23-16edc591a977",
         "price": 62.77
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0d42e4a7-bac4-45c9-8287-3e79f86d52e9",
         "price": 21.5
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "800ac955-1219-41e3-be42-5de784f9c572",
         "price": 59.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "99994529-4472-4bd0-9027-6535592d2042",
         "price": 51.58
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "583fe6a1-37c6-4277-aeb1-aa175ce655d0",
         "price": 26.07
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5f17c1ae-aa66-43a6-8df2-9956ac6f957a",
         "price": 88.38
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "00a0b2c4-f396-41dd-ae16-968f92d8f030",
         "price": 31.59
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "7056076b-9a68-4075-9011-147b160d239b",
         "price": 13.93
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4415f4f7-b19c-4289-b228-52c03bdf5a7b",
         "price": 93.27
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bc623209-cd51-4b1f-aeb2-d08328574bd0",
         "price": 18.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0a8c5dd0-7350-472a-a39a-90ad57aee219",
         "price": 97.56
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ee0885a0-959e-40fb-a8da-03b5280b2942",
         "price": 68.56
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "30d9279d-41e6-42ea-991a-49a90c94b8c8",
         "price": 28.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4c8df981-035e-467c-8a38-980fc05ea142",
         "price": 55.73
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "820f2bcb-0cef-4225-a7b2-631d0ac93aa0",
         "price": 44.11
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a86c5079-3968-47a5-8836-14b7932fcaab",
         "price": 12.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2b802dbd-de2a-4328-a4fb-d6ee695a0f91",
         "price": 86.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3ed4ec36-0606-4d69-abe8-166b113074b6",
         "price": 95.24
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "09184681-ed1c-4f3e-b3ad-657cb9d46f4d",
         "price": 92.48
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "69022ff3-6684-4a3f-b1da-a086021207b1",
         "price": 29.81
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9ccabd47-38e2-4f5e-8bb5-91cbc8c0afde",
         "price": 71.54
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "704aad4f-80ac-437b-bd3c-1bcdebdd35f2",
         "price": 22.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "baaa4a66-b0ff-4523-950d-587834300a15",
         "price": 66.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9c3f20c3-c69f-4edf-951f-039f1555eacd",
         "price": 31.19
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "efb46b6d-8d5b-4b17-b91d-7e5270c361d1",
         "price": 46.33
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9e1476e9-0358-4a5e-a344-96d62efcba77",
         "price": 12.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a8428a0b-5900-4d8a-a190-2bde379399c5",
         "price": 65.37
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "c375e2c5-58ad-45d5-8897-efe1ebff9f27",
         "price": 99.55
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "045ee60c-d4da-4652-843e-5c3f66f63cab",
         "price": 53.93
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e32bc42b-43df-4d8e-8c0d-0c95a99f7a45",
         "price": 66.94
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "16edef34-fe77-4501-bf07-54daf7755ee6",
         "price": 48.01
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8c8ccc98-2b70-4f42-a3dd-1c920243e93d",
         "price": 59.3
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3d18334a-dd32-450c-a62f-7bed9be45caa",
         "price": 79.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2f0bde57-fd36-4e55-97a7-c3149b647454",
         "price": 37.79
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "bdb09f36-bfce-4d85-a573-d6a619d6cf14",
         "price": 44.73
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "770fc025-937b-4165-9107-a3d1e2f43755",
         "price": 84.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "b140d6df-6523-4d7d-a774-93b2e73e4c8f",
         "price": 40.27
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1df7eacc-0957-4414-bd41-317a4b261ae1",
         "price": 19.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1f246c67-2282-429f-bec4-a4edd9492598",
         "price": 72.99
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "afc4c4a1-203b-45f8-8b31-e02eef27b103",
         "price": 77.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "3b4d422b-3604-4e7d-ad03-6f24945c7837",
         "price": 44.98
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e8f842a2-cfda-4c9a-bcbc-5dbb096aed02",
         "price": 43.93
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0da2d9f1-be13-4f4f-8129-e475330e7a1b",
         "price": 37.34
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5312595c-07cf-42b0-ae82-8cb376311fd5",
         "price": 80.52
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5237f4f0-4b88-41ae-8d13-d054fefe1021",
         "price": 18.45
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8517594f-46d0-4d1a-93c9-84bec084f9c6",
         "price": 52.84
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "687a0fde-2408-463e-b291-2c9088080cdc",
         "price": 96.44
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "45bead4a-c7e7-459b-b832-c1d660496849",
         "price": 64.39
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8a80055a-204c-4e91-85c9-10532b559923",
         "price": 71.4
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ec975187-76c4-4636-9b0d-c67ab85c0f50",
         "price": 43.11
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "1d0dd6e3-d9ad-4981-bd08-0e195b69e875",
         "price": 83.8
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "815d6008-9ced-4236-ae54-a37cb6f4e3ad",
         "price": 73.88
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e706710f-cfab-4b35-84ca-fdfe21761da2",
         "price": 72.76
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d2c790ad-7912-4e02-b4d7-fc014d72b6b5",
         "price": 60.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "02ca6743-0f69-4573-acf7-1d2245203db4",
         "price": 45.98
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "775f2b40-8135-4eae-8de9-b9c4a3e1cdb7",
         "price": 12.68
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5a0f1de6-9e85-40b1-a9e2-3b8c6aedc6a8",
         "price": 89.04
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d2f1c0df-349e-4dfc-9572-d0fca1750677",
         "price": 68.4
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5cfafcfa-1352-4be7-a9a7-a1893e9de37b",
         "price": 92.55
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4fed9bdc-3522-489b-999d-6ed77f4c057f",
         "price": 85.23
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6cbc9c65-63f9-45b6-8645-371fbaf595df",
         "price": 58.15
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "41d3b195-290f-4c27-a012-f3a1524dae94",
         "price": 34.33
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f4a4e235-e381-4050-ba39-82d40df67781",
         "price": 92.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9b1a4f43-a092-4125-a4c4-149bf4184146",
         "price": 10.96
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5fb036ef-fe78-4d87-a307-85c2b0d49e74",
         "price": 66.58
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "26bf41c7-676f-45b1-8f84-bfb4d8c9880e",
         "price": 22
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "98a9ad14-7dff-4e94-b816-cba8c5100fcc",
         "price": 24.17
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "298dd5c1-a28f-4c35-b712-65881d070aea",
         "price": 67.17
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8ba6282f-37fd-45c7-b160-7af2e7d068a6",
         "price": 56.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "55728347-f20c-46c1-816e-3e0d8ef4b726",
         "price": 74.63
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "04fc062d-663d-498f-aef6-b3f30e6558cb",
         "price": 26.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "10daf855-86ea-4409-ae88-4744e1870504",
         "price": 11.41
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6322ad5b-b72a-4064-b6dd-be34358817f7",
         "price": 16.01
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ffd4bad8-1bf7-4250-a9a4-e1f54fdc10d5",
         "price": 49.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6b4d3f27-9aea-4e7d-a6eb-eff711d808a8",
         "price": 42.08
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ca02d945-7a18-43f4-9bdc-38a1b1c68f5d",
         "price": 82.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4195b00b-47f5-437f-bb06-eda59f9f682f",
         "price": 87.6
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6756d4ae-f530-4661-8aeb-2ab6284bacb6",
         "price": 61.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4255bbdb-bb6f-46b0-b825-9161e79dbd92",
         "price": 12.29
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "840282b7-0bce-4380-9f9f-4210796c82e1",
         "price": 25.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6d997b00-a456-474f-a0b9-d5e3633d0019",
         "price": 70.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ef611765-09d4-4632-888a-9d9d9a81336f",
         "price": 66.34
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f7b2c72f-5725-4af4-b272-f28569e82591",
         "price": 95.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5c4717a1-c304-4913-a134-c27ee1b742f3",
         "price": 21.06
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "286a229a-7b22-4f88-81ba-3f466b114dd0",
         "price": 67.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d308af2d-477b-4135-b406-b638a936175f",
         "price": 99.21
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "d68aa398-90db-402d-a577-e34ece516722",
         "price": 67.19
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "41a181ba-2556-4cac-8bf5-af8e84d86269",
         "price": 12.46
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "16034c09-ff1b-4fb9-b9c3-4fd4ff89bc34",
         "price": 96.67
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "32022528-0f91-47d9-a399-13172af9a182",
         "price": 92.85
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f485abec-c413-474e-94d6-40e4c08506b8",
         "price": 56.13
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4bba37ed-7ede-4937-9d26-4c6185f74fbf",
         "price": 77.78
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "2285f54b-4f3f-4582-814b-144d93f3bb8c",
         "price": 30.92
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "856271e8-0b78-4c1c-944e-6d180f8e15b4",
         "price": 85.12
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f64c4395-a5a1-40f6-ad37-d48b9287bdc0",
         "price": 56.02
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "5c77a791-8e1b-4a99-9f87-9ef5895c2281",
         "price": 43.75
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "9bd57e74-f5bd-41f6-a961-d102c689ff88",
         "price": 17.26
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f81ac39a-36e9-4005-a915-169c1d5576ff",
         "price": 70.66
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "32a770bd-6af8-4600-a090-a39fc1ca0ec3",
         "price": 87.94
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "e3dd54b6-2eef-4101-a66a-9825b96617e6",
         "price": 97.97
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "61bc7cba-eca1-4cb1-aa68-2c31bd6af9ac",
         "price": 40.6
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "0b3a2df5-99f9-4014-9c6f-3943507f4de2",
         "price": 55.74
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "57f12931-dd3a-4f67-b3ed-a490d9a77377",
         "price": 93.65
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a551ec68-b696-4735-8b8c-f81fbe538f68",
         "price": 55.71
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "96b9a7ce-fd06-4715-9bbc-fd8df68dffb0",
         "price": 77.98
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "a61781fa-2728-4137-88cf-5ad028c98b76",
         "price": 50.89
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "f75bd3b0-b76f-40c4-a896-09268750637b",
         "price": 45.09
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "4090dea0-ca9b-4c6f-ad31-499640f42b75",
         "price": 78.69
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "71d67ee8-35c0-4b63-9e4b-3c9caed55492",
         "price": 18.78
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "8b2ae184-7a69-422c-be31-6e9009f5b5e3",
         "price": 83.94
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "6c964b1c-6691-4dfd-bd15-fac772eba8de",
         "price": 83.64
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "ae6beada-f8ee-4847-a519-46598428929a",
         "price": 82.85
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     },
     {
       "log_level": "info",
-      "event": "PaymentSubmitted",
+      "event": "request_finished",
       "body": {
         "token": "782ae3cd-76fb-455f-a05a-34e8c057d495",
         "price": 21.31
+      },
+      "message": {
+        "event": "PaymentSubmitted"
       }
     }
   ]

--- a/data/success/ride-created.json
+++ b/data/success/ride-created.json
@@ -1,4502 +1,6002 @@
 [
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Thornton Street 330, Harrodsburg, USA",
         "dropoff": "Remsen Avenue 973, Zarephath, USA",
         "price": 83.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lois Avenue 942, Fivepointville, USA",
         "dropoff": "Lester Court 911, Grill, USA",
         "price": 99.93
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Orient Avenue 13, Sutton, USA",
         "dropoff": "Elliott Place 806, Orason, USA",
         "price": 64.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Mermaid Avenue 621, Westmoreland, USA",
         "dropoff": "Franklin Street 756, Hachita, USA",
         "price": 91.85
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Eaton Court 273, Rivera, USA",
         "dropoff": "Conselyea Street 417, Byrnedale, USA",
         "price": 66.23
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Humboldt Street 341, Malott, USA",
         "dropoff": "Noble Street 613, Barrelville, USA",
         "price": 23.42
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bayview Avenue 365, Sabillasville, USA",
         "dropoff": "Lorimer Street 777, Tonopah, USA",
         "price": 76.89
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gain Court 884, Jacumba, USA",
         "dropoff": "Mill Road 828, Goochland, USA",
         "price": 19.39
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Aurelia Court 201, Suitland, USA",
         "dropoff": "Bragg Street 702, Strykersville, USA",
         "price": 92.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sackett Street 310, Brazos, USA",
         "dropoff": "Meserole Avenue 266, Blanford, USA",
         "price": 41.78
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cornelia Street 981, Dellview, USA",
         "dropoff": "Forrest Street 378, Hatteras, USA",
         "price": 50.63
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dewey Place 23, Allensworth, USA",
         "dropoff": "Doscher Street 494, Bodega, USA",
         "price": 31.58
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Varick Street 199, Blende, USA",
         "dropoff": "Gelston Avenue 705, Dunbar, USA",
         "price": 94.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Voorhies Avenue 533, Warsaw, USA",
         "dropoff": "Clarendon Road 36, Grantville, USA",
         "price": 62.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hopkins Street 69, Riceville, USA",
         "dropoff": "Wythe Avenue 110, Catherine, USA",
         "price": 23.59
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kent Street 242, Lynn, USA",
         "dropoff": "Claver Place 958, Gorham, USA",
         "price": 31.39
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hoyts Lane 833, Bridgetown, USA",
         "dropoff": "Hazel Court 81, Newcastle, USA",
         "price": 34.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ingraham Street 848, Mahtowa, USA",
         "dropoff": "Apollo Street 511, Nogal, USA",
         "price": 66.63
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bushwick Court 594, Loomis, USA",
         "dropoff": "Oxford Walk 656, Drytown, USA",
         "price": 59.14
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Neptune Avenue 475, Edgewater, USA",
         "dropoff": "Fenimore Street 145, Canoochee, USA",
         "price": 82.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Matthews Place 33, Gasquet, USA",
         "dropoff": "Hall Street 931, Kimmell, USA",
         "price": 85.03
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gerry Street 450, Villarreal, USA",
         "dropoff": "Ebony Court 679, Turpin, USA",
         "price": 69.14
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Adler Place 617, Ventress, USA",
         "dropoff": "Guernsey Street 987, Bendon, USA",
         "price": 95.58
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gold Street 665, Springville, USA",
         "dropoff": "Norwood Avenue 275, Bordelonville, USA",
         "price": 57.47
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Autumn Avenue 473, Temperanceville, USA",
         "dropoff": "Scott Avenue 984, Libertytown, USA",
         "price": 47.16
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Oxford Street 248, Groveville, USA",
         "dropoff": "Nassau Street 54, Jackpot, USA",
         "price": 41.48
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Will Place 403, Gwynn, USA",
         "dropoff": "Aster Court 634, Concho, USA",
         "price": 97.92
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Desmond Court 669, Irwin, USA",
         "dropoff": "Visitation Place 546, Topanga, USA",
         "price": 77.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Decatur Street 63, Waterview, USA",
         "dropoff": "Oceanic Avenue 316, Skyland, USA",
         "price": 15.63
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Oceanview Avenue 527, Esmont, USA",
         "dropoff": "Morton Street 512, Rockhill, USA",
         "price": 79.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Main Street 984, Hillsboro, USA",
         "dropoff": "Gunnison Court 85, Smock, USA",
         "price": 68.82
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Navy Walk 202, Conestoga, USA",
         "dropoff": "Bartlett Street 607, Freetown, USA",
         "price": 49.62
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Stryker Court 916, Floriston, USA",
         "dropoff": "McDonald Avenue 502, Drummond, USA",
         "price": 68.48
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fleet Walk 64, Healy, USA",
         "dropoff": "Virginia Place 980, Brandywine, USA",
         "price": 61.36
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hull Street 29, Toftrees, USA",
         "dropoff": "Kimball Street 890, Franklin, USA",
         "price": 82.27
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Surf Avenue 551, Oceola, USA",
         "dropoff": "Reed Street 450, Knowlton, USA",
         "price": 67.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hill Street 285, Eden, USA",
         "dropoff": "Sharon Street 643, Finderne, USA",
         "price": 22.99
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seigel Street 558, Gadsden, USA",
         "dropoff": "Jerome Avenue 518, Cloverdale, USA",
         "price": 61.04
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Schenck Street 690, Alamo, USA",
         "dropoff": "Dare Court 355, Volta, USA",
         "price": 30.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Franklin Avenue 514, Breinigsville, USA",
         "dropoff": "Moffat Street 673, Gambrills, USA",
         "price": 99.49
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Coleridge Street 776, Loyalhanna, USA",
         "dropoff": "Karweg Place 843, Fontanelle, USA",
         "price": 50.85
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kings Hwy 329, Smeltertown, USA",
         "dropoff": "Pineapple Street 249, Machias, USA",
         "price": 89.21
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rewe Street 451, Kiskimere, USA",
         "dropoff": "Commerce Street 113, Golconda, USA",
         "price": 85.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ridgewood Avenue 813, Richmond, USA",
         "dropoff": "Martense Street 556, Bangor, USA",
         "price": 39.89
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Story Street 429, Haring, USA",
         "dropoff": "Mill Street 30, Callaghan, USA",
         "price": 77.9
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Quentin Road 175, Torboy, USA",
         "dropoff": "Monitor Street 697, Bluetown, USA",
         "price": 59.34
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Columbia Street 328, Roosevelt, USA",
         "dropoff": "Wortman Avenue 446, Bynum, USA",
         "price": 48.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hart Street 953, Kilbourne, USA",
         "dropoff": "Highland Boulevard 490, Wanship, USA",
         "price": 27.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "John Street 796, Greenock, USA",
         "dropoff": "Colby Court 784, Emison, USA",
         "price": 20.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Albee Square 934, Fairmount, USA",
         "dropoff": "Highlawn Avenue 159, Retsof, USA",
         "price": 87.43
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lincoln Terrace 792, Robbins, USA",
         "dropoff": "Fleet Place 819, Barstow, USA",
         "price": 58.16
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ditmas Avenue 283, Elliott, USA",
         "dropoff": "Murdock Court 477, Newry, USA",
         "price": 57.92
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bank Street 501, Grimsley, USA",
         "dropoff": "Danforth Street 131, Geyserville, USA",
         "price": 46.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Foster Avenue 145, Macdona, USA",
         "dropoff": "Sutter Avenue 931, Corinne, USA",
         "price": 87.98
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "National Drive 185, Ada, USA",
         "dropoff": "Olive Street 380, Waverly, USA",
         "price": 96.62
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Woods Place 642, Woodburn, USA",
         "dropoff": "Crawford Avenue 515, Bend, USA",
         "price": 62.72
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Commercial Street 720, Roberts, USA",
         "dropoff": "Trucklemans Lane 554, Nord, USA",
         "price": 74.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Summit Street 585, Dotsero, USA",
         "dropoff": "Lincoln Avenue 652, Hinsdale, USA",
         "price": 18.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bridgewater Street 468, Troy, USA",
         "dropoff": "Beacon Court 617, Kipp, USA",
         "price": 16.55
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Halsey Street 777, Lindisfarne, USA",
         "dropoff": "Legion Street 382, Edenburg, USA",
         "price": 87.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Havens Place 487, Greer, USA",
         "dropoff": "Pitkin Avenue 744, Edgar, USA",
         "price": 79.73
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Aberdeen Street 968, Welch, USA",
         "dropoff": "Coles Street 217, Kerby, USA",
         "price": 91.74
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gunther Place 170, Onton, USA",
         "dropoff": "Regent Place 514, Rowe, USA",
         "price": 66.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Keap Street 180, Witmer, USA",
         "dropoff": "Abbey Court 588, Convent, USA",
         "price": 63.42
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Anthony Street 710, Shawmut, USA",
         "dropoff": "Nova Court 441, Farmers, USA",
         "price": 65.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Pilling Street 453, Sunnyside, USA",
         "dropoff": "Boulevard Court 324, Bancroft, USA",
         "price": 35.52
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Furman Avenue 864, Snowville, USA",
         "dropoff": "Dearborn Court 941, Orovada, USA",
         "price": 72.17
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Henry Street 258, Graball, USA",
         "dropoff": "McClancy Place 272, Castleton, USA",
         "price": 75.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Grove Street 776, Iola, USA",
         "dropoff": "School Lane 633, Gardiner, USA",
         "price": 55.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dean Street 86, Sidman, USA",
         "dropoff": "Amboy Street 47, Chapin, USA",
         "price": 71.5
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hendrickson Street 480, Chicopee, USA",
         "dropoff": "Veterans Avenue 445, Teasdale, USA",
         "price": 64.36
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Wakeman Place 306, Axis, USA",
         "dropoff": "Opal Court 427, Vienna, USA",
         "price": 16.82
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Schenck Court 350, Wikieup, USA",
         "dropoff": "Portland Avenue 56, Kingstowne, USA",
         "price": 35.58
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Euclid Avenue 758, Osage, USA",
         "dropoff": "Meadow Street 93, Limestone, USA",
         "price": 21.42
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Beaumont Street 644, Bergoo, USA",
         "dropoff": "Gaylord Drive 313, Deltaville, USA",
         "price": 92.45
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Berriman Street 277, Bath, USA",
         "dropoff": "Nichols Avenue 77, Chesapeake, USA",
         "price": 84.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Montgomery Street 97, Whitestone, USA",
         "dropoff": "Prescott Place 706, Templeton, USA",
         "price": 86.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Middleton Street 418, Kenvil, USA",
         "dropoff": "Provost Street 783, Valmy, USA",
         "price": 73.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rockwell Place 279, Chumuckla, USA",
         "dropoff": "Underhill Avenue 545, Nile, USA",
         "price": 83.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Wyckoff Street 844, Reinerton, USA",
         "dropoff": "Roebling Street 875, Iberia, USA",
         "price": 51.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Montrose Avenue 294, Jennings, USA",
         "dropoff": "Amherst Street 333, Saticoy, USA",
         "price": 95.41
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Joralemon Street 980, Reno, USA",
         "dropoff": "Rogers Avenue 19, Muir, USA",
         "price": 60.71
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Anna Court 136, Cashtown, USA",
         "dropoff": "Tehama Street 96, Detroit, USA",
         "price": 12.3
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Barwell Terrace 756, Interlochen, USA",
         "dropoff": "Broome Street 935, Summertown, USA",
         "price": 80.07
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kansas Place 5, Draper, USA",
         "dropoff": "Dorset Street 887, Watchtower, USA",
         "price": 98.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Louis Place 149, Cleary, USA",
         "dropoff": "Amity Street 493, Rose, USA",
         "price": 30.06
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Robert Street 226, Walker, USA",
         "dropoff": "Clarkson Avenue 750, Kieler, USA",
         "price": 69.39
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Whitty Lane 256, Gilgo, USA",
         "dropoff": "Hunts Lane 871, Riner, USA",
         "price": 34.57
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Caton Place 310, Broadlands, USA",
         "dropoff": "Livingston Street 440, Spokane, USA",
         "price": 39.03
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sunnyside Avenue 968, Baker, USA",
         "dropoff": "Judge Street 99, Itmann, USA",
         "price": 90.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Miller Place 903, Shindler, USA",
         "dropoff": "Jefferson Avenue 381, Elwood, USA",
         "price": 44.32
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ridgecrest Terrace 490, Westboro, USA",
         "dropoff": "Prospect Avenue 342, Albany, USA",
         "price": 59.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Waldorf Court 708, Calpine, USA",
         "dropoff": "Ocean Court 932, Allison, USA",
         "price": 73.13
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sullivan Place 560, Lisco, USA",
         "dropoff": "Banner Avenue 879, Ruckersville, USA",
         "price": 30.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hamilton Walk 917, Brutus, USA",
         "dropoff": "Prospect Street 889, Darlington, USA",
         "price": 48.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Canal Avenue 344, Fulford, USA",
         "dropoff": "Dumont Avenue 105, Statenville, USA",
         "price": 71.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hendrix Street 552, Hayden, USA",
         "dropoff": "Belmont Avenue 688, Albrightsville, USA",
         "price": 53.31
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Harman Street 229, Bowmansville, USA",
         "dropoff": "Gotham Avenue 336, Tecolotito, USA",
         "price": 87.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Branton Street 415, Camino, USA",
         "dropoff": "Williams Place 310, Grazierville, USA",
         "price": 36.48
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sands Street 620, Century, USA",
         "dropoff": "Crooke Avenue 369, Ladera, USA",
         "price": 81.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seabring Street 970, Tampico, USA",
         "dropoff": "Drew Street 802, Denio, USA",
         "price": 84.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Agate Court 486, Barclay, USA",
         "dropoff": "Minna Street 610, Westerville, USA",
         "price": 14.07
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dinsmore Place 276, Clay, USA",
         "dropoff": "Dunham Place 91, Dennard, USA",
         "price": 35.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Battery Avenue 853, Lowgap, USA",
         "dropoff": "Dahl Court 868, Diaperville, USA",
         "price": 12.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Newkirk Placez 812, Leeper, USA",
         "dropoff": "Chester Court 981, Orin, USA",
         "price": 38.73
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Blake Avenue 392, Grandview, USA",
         "dropoff": "Georgia Avenue 799, Enoree, USA",
         "price": 92.57
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gatling Place 898, Tuttle, USA",
         "dropoff": "Horace Court 1000, Weogufka, USA",
         "price": 23.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Florence Avenue 991, Herlong, USA",
         "dropoff": "Linden Street 628, Sharon, USA",
         "price": 13.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Jackson Street 245, Wolcott, USA",
         "dropoff": "Village Court 392, Thermal, USA",
         "price": 88.62
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gerald Court 225, Coleville, USA",
         "dropoff": "Hubbard Place 606, Motley, USA",
         "price": 71.89
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cyrus Avenue 496, Norris, USA",
         "dropoff": "Ovington Avenue 353, Harviell, USA",
         "price": 79.23
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Calyer Street 593, Mulino, USA",
         "dropoff": "Chase Court 159, Wiscon, USA",
         "price": 56.69
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Pine Street 209, Chemung, USA",
         "dropoff": "Myrtle Avenue 886, Beyerville, USA",
         "price": 41.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lyme Avenue 853, Urie, USA",
         "dropoff": "Vandam Street 500, Monument, USA",
         "price": 33.86
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cypress Avenue 711, Wells, USA",
         "dropoff": "Rose Street 836, Wadsworth, USA",
         "price": 15.13
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ash Street 192, Emerald, USA",
         "dropoff": "Kensington Street 460, Kylertown, USA",
         "price": 20.15
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Polar Street 392, Guilford, USA",
         "dropoff": "Forest Place 206, Bawcomville, USA",
         "price": 71.74
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Truxton Street 798, Lutsen, USA",
         "dropoff": "Pershing Loop 383, Rutherford, USA",
         "price": 71.71
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Colin Place 920, Jenkinsville, USA",
         "dropoff": "Tennis Court 780, Ballico, USA",
         "price": 36.16
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cedar Street 208, Nicut, USA",
         "dropoff": "Elm Place 931, Hollymead, USA",
         "price": 57.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lott Street 756, Maxville, USA",
         "dropoff": "Atlantic Avenue 59, Beechmont, USA",
         "price": 84.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rutland Road 166, Frizzleburg, USA",
         "dropoff": "Meserole Street 420, Grapeview, USA",
         "price": 45.57
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Maple Avenue 334, Goldfield, USA",
         "dropoff": "Vanderveer Street 644, Chalfant, USA",
         "price": 95.68
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bogart Street 866, Ruffin, USA",
         "dropoff": "Grattan Street 939, Vaughn, USA",
         "price": 68.6
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Emerson Place 607, Rockbridge, USA",
         "dropoff": "Quincy Street 790, Wildwood, USA",
         "price": 66.49
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Chauncey Street 613, Wyoming, USA",
         "dropoff": "Herkimer Street 977, Twilight, USA",
         "price": 58.55
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lacon Court 733, Dante, USA",
         "dropoff": "Metropolitan Avenue 412, Rote, USA",
         "price": 72.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Duryea Court 136, Vivian, USA",
         "dropoff": "Ryder Street 250, Leyner, USA",
         "price": 68.93
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Albemarle Terrace 147, Fairlee, USA",
         "dropoff": "Wyona Street 984, Canterwood, USA",
         "price": 76.08
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Harwood Place 488, Downsville, USA",
         "dropoff": "Dictum Court 518, Takilma, USA",
         "price": 91.52
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gardner Avenue 931, Greenbackville, USA",
         "dropoff": "Sapphire Street 683, Brownlee, USA",
         "price": 47.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rochester Avenue 943, Crayne, USA",
         "dropoff": "Lombardy Street 249, Odessa, USA",
         "price": 89.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dunne Place 358, Noxen, USA",
         "dropoff": "Congress Street 239, Taft, USA",
         "price": 67.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Central Avenue 501, Comptche, USA",
         "dropoff": "Vandalia Avenue 222, Blairstown, USA",
         "price": 16.66
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Flatbush Avenue 645, Verdi, USA",
         "dropoff": "Willow Street 822, Wilsonia, USA",
         "price": 77.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Jefferson Street 922, Echo, USA",
         "dropoff": "Moore Place 207, Cascades, USA",
         "price": 58.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Strong Place 896, Idledale, USA",
         "dropoff": "Benson Avenue 37, Allentown, USA",
         "price": 93.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cumberland Street 244, Glendale, USA",
         "dropoff": "Boerum Place 189, Eggertsville, USA",
         "price": 46.68
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Portal Street 7, Leming, USA",
         "dropoff": "Fayette Street 675, Kansas, USA",
         "price": 94.38
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Suydam Place 126, Chase, USA",
         "dropoff": "Gates Avenue 89, Robinson, USA",
         "price": 90.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Boardwalk  448, Orviston, USA",
         "dropoff": "Homecrest Court 910, Brethren, USA",
         "price": 93.46
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Temple Court 784, Ernstville, USA",
         "dropoff": "Kaufman Place 544, Harrison, USA",
         "price": 92.07
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Glenmore Avenue 660, Lacomb, USA",
         "dropoff": "Lancaster Avenue 544, Norwood, USA",
         "price": 38.32
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sheffield Avenue 338, Bonanza, USA",
         "dropoff": "Lloyd Court 16, Floris, USA",
         "price": 14.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bryant Street 108, Tolu, USA",
         "dropoff": "Arion Place 408, Rossmore, USA",
         "price": 73.18
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Stockholm Street 302, Aguila, USA",
         "dropoff": "Duryea Place 511, Islandia, USA",
         "price": 23.83
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Monroe Place 589, Trucksville, USA",
         "dropoff": "Haring Street 57, Crisman, USA",
         "price": 60.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bradford Street 115, Colton, USA",
         "dropoff": "Freeman Street 986, Fairview, USA",
         "price": 27.96
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kermit Place 513, Cataract, USA",
         "dropoff": "Walker Court 65, Caln, USA",
         "price": 61.27
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Metrotech Courtr 888, Dale, USA",
         "dropoff": "Heyward Street 838, Snyderville, USA",
         "price": 38.85
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cass Place 656, Bagtown, USA",
         "dropoff": "Evans Street 830, Marienthal, USA",
         "price": 88.5
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Noll Street 192, Brownsville, USA",
         "dropoff": "Douglass Street 218, Saddlebrooke, USA",
         "price": 11.76
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Catherine Street 58, Rosburg, USA",
         "dropoff": "Lafayette Walk 551, Tioga, USA",
         "price": 72.92
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "High Street 214, Faywood, USA",
         "dropoff": "Belvidere Street 635, Marbury, USA",
         "price": 62.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Albemarle Road 992, Frystown, USA",
         "dropoff": "Ford Street 974, Katonah, USA",
         "price": 66.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Devon Avenue 611, Rivers, USA",
         "dropoff": "Glendale Court 746, Forbestown, USA",
         "price": 34.08
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Homecrest Avenue 997, Hayes, USA",
         "dropoff": "Roosevelt Place 331, Enetai, USA",
         "price": 85.76
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cove Lane 643, Mathews, USA",
         "dropoff": "Nixon Court 521, Inkerman, USA",
         "price": 61.16
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Tapscott Avenue 773, Riverton, USA",
         "dropoff": "Calder Place 541, Clinton, USA",
         "price": 79.62
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Emmons Avenue 787, Ebro, USA",
         "dropoff": "Plymouth Street 144, Avalon, USA",
         "price": 32.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Clark Street 480, Belva, USA",
         "dropoff": "Broadway  157, Crenshaw, USA",
         "price": 10.62
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Clay Street 945, Chilton, USA",
         "dropoff": "Bokee Court 316, Frierson, USA",
         "price": 86
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Conway Street 246, Yonah, USA",
         "dropoff": "Bethel Loop 181, Brady, USA",
         "price": 62.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Roosevelt Court 778, Cetronia, USA",
         "dropoff": "Hope Street 803, National, USA",
         "price": 58.83
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hubbard Street 292, Munjor, USA",
         "dropoff": "Hemlock Street 747, Sanders, USA",
         "price": 92.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Farragut Road 772, Delshire, USA",
         "dropoff": "Montague Street 612, Wakarusa, USA",
         "price": 68.46
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Suydam Street 147, Noblestown, USA",
         "dropoff": "Eckford Street 821, Cumberland, USA",
         "price": 34.3
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Nelson Street 887, Leland, USA",
         "dropoff": "Lefferts Avenue 39, Gilmore, USA",
         "price": 25.26
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Doughty Street 389, Moraida, USA",
         "dropoff": "Flatlands Avenue 199, Nash, USA",
         "price": 78.38
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Perry Place 408, Whitewater, USA",
         "dropoff": "Union Avenue 294, Centerville, USA",
         "price": 87.14
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Howard Avenue 911, Harmon, USA",
         "dropoff": "Herbert Street 245, Sisquoc, USA",
         "price": 12.4
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Richardson Street 673, Hebron, USA",
         "dropoff": "Louisiana Avenue 140, Rosine, USA",
         "price": 48.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Melrose Street 409, Elizaville, USA",
         "dropoff": "Tech Place 723, Blackgum, USA",
         "price": 26.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sedgwick Street 951, Bennett, USA",
         "dropoff": "King Street 492, Tyro, USA",
         "price": 62.57
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Monroe Street 907, Movico, USA",
         "dropoff": "Debevoise Avenue 270, Conway, USA",
         "price": 72.07
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bayview Place 634, Winesburg, USA",
         "dropoff": "Newel Street 286, Fidelis, USA",
         "price": 32.73
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hooper Street 254, Mayfair, USA",
         "dropoff": "Village Road 874, Enlow, USA",
         "price": 15.83
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Elliott Walk 448, Lodoga, USA",
         "dropoff": "Albany Avenue 441, Biddle, USA",
         "price": 73.46
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lott Place 160, Oberlin, USA",
         "dropoff": "Hastings Street 909, Coral, USA",
         "price": 80.8
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kenilworth Place 609, Taycheedah, USA",
         "dropoff": "Times Placez 70, Thatcher, USA",
         "price": 43.93
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Aitken Place 309, Lithium, USA",
         "dropoff": "Wilson Street 723, Brogan, USA",
         "price": 25.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Harbor Court 692, Brambleton, USA",
         "dropoff": "Coventry Road 492, Valle, USA",
         "price": 31.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Manhattan Court 811, Salvo, USA",
         "dropoff": "Losee Terrace 249, Gardners, USA",
         "price": 21.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Grafton Street 800, Glidden, USA",
         "dropoff": "Strauss Street 928, Bowden, USA",
         "price": 57.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lynch Street 167, Northridge, USA",
         "dropoff": "Chapel Street 309, Hiseville, USA",
         "price": 65.37
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Grove Place 953, Richford, USA",
         "dropoff": "Putnam Avenue 460, Sparkill, USA",
         "price": 34.6
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Joval Court 182, Edmund, USA",
         "dropoff": "Pierrepont Place 2, Curtice, USA",
         "price": 90.37
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Railroad Avenue 972, Johnsonburg, USA",
         "dropoff": "Dakota Place 973, Wakulla, USA",
         "price": 69.63
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Baltic Street 658, Cumminsville, USA",
         "dropoff": "Hausman Street 84, Waterford, USA",
         "price": 78.66
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Post Court 433, Gerber, USA",
         "dropoff": "Debevoise Street 400, Beaulieu, USA",
         "price": 78.01
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dupont Street 606, Eagletown, USA",
         "dropoff": "Ashland Place 615, Boykin, USA",
         "price": 49.96
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Vista Place 169, Rodman, USA",
         "dropoff": "Dewitt Avenue 386, Nelson, USA",
         "price": 88.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Veranda Place 680, Selma, USA",
         "dropoff": "Girard Street 125, Northchase, USA",
         "price": 30.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ira Court 296, Ola, USA",
         "dropoff": "Gem Street 808, Carrizo, USA",
         "price": 27.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Herkimer Court 581, Wheatfields, USA",
         "dropoff": "Bush Street 672, Rushford, USA",
         "price": 69
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hillel Place 594, Newkirk, USA",
         "dropoff": "Dobbin Street 326, Urbana, USA",
         "price": 50.71
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Burnett Street 968, Alden, USA",
         "dropoff": "Malta Street 75, Gratton, USA",
         "price": 18.07
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fiske Place 153, Coultervillle, USA",
         "dropoff": "Bulwer Place 393, Dawn, USA",
         "price": 23.52
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Box Street 228, Shepardsville, USA",
         "dropoff": "Keen Court 578, Coloma, USA",
         "price": 60.4
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Woodside Avenue 47, Bison, USA",
         "dropoff": "Tiffany Place 78, Loma, USA",
         "price": 15.48
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Micieli Place 670, Bentley, USA",
         "dropoff": "Etna Street 26, Waterloo, USA",
         "price": 10.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Forbell Street 497, Umapine, USA",
         "dropoff": "India Street 394, Nutrioso, USA",
         "price": 45.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Goodwin Place 359, Crawfordsville, USA",
         "dropoff": "Hart Place 371, Sardis, USA",
         "price": 90.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Adelphi Street 777, Boyd, USA",
         "dropoff": "Winthrop Street 94, Nanafalia, USA",
         "price": 92.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Quay Street 673, Craig, USA",
         "dropoff": "Bowne Street 975, Ferney, USA",
         "price": 30.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Arkansas Drive 883, Greenbush, USA",
         "dropoff": "Milton Street 162, Sunriver, USA",
         "price": 89.29
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Clifton Place 709, Alafaya, USA",
         "dropoff": "Hinckley Place 865, Riviera, USA",
         "price": 29.8
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Erskine Loop 526, Brandermill, USA",
         "dropoff": "Croton Loop 371, Ogema, USA",
         "price": 66.92
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Caton Avenue 526, Wanamie, USA",
         "dropoff": "Holt Court 200, Omar, USA",
         "price": 12.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bergen Avenue 266, Fillmore, USA",
         "dropoff": "Dahill Road 839, Highland, USA",
         "price": 10.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sumpter Street 830, Veyo, USA",
         "dropoff": "Ellery Street 252, Maplewood, USA",
         "price": 45.17
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Leonora Court 443, Genoa, USA",
         "dropoff": "Seagate Terrace 763, Graniteville, USA",
         "price": 59.14
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Pleasant Place 401, Klondike, USA",
         "dropoff": "Hanson Place 298, Sims, USA",
         "price": 67.08
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Jackson Place 255, Wattsville, USA",
         "dropoff": "Crystal Street 587, Gloucester, USA",
         "price": 21.49
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Engert Avenue 60, Tetherow, USA",
         "dropoff": "Clifford Place 627, Zeba, USA",
         "price": 39.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Stratford Road 480, Carrsville, USA",
         "dropoff": "Schenck Place 734, Whitehaven, USA",
         "price": 32.61
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bassett Avenue 656, Avoca, USA",
         "dropoff": "Bills Place 34, Juntura, USA",
         "price": 32.39
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Banker Street 745, Tooleville, USA",
         "dropoff": "Brigham Street 540, Belfair, USA",
         "price": 62.67
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gilmore Court 514, Marne, USA",
         "dropoff": "Ludlam Place 493, Jacksonburg, USA",
         "price": 53.31
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Verona Place 42, Dubois, USA",
         "dropoff": "Greenwood Avenue 407, Connerton, USA",
         "price": 96.3
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Glen Street 829, Succasunna, USA",
         "dropoff": "Frank Court 160, Sperryville, USA",
         "price": 79.23
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bristol Street 892, Kennedyville, USA",
         "dropoff": "Barbey Street 978, Stewartville, USA",
         "price": 85.7
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lafayette Avenue 889, Swartzville, USA",
         "dropoff": "Grand Street 784, Groton, USA",
         "price": 37.62
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kane Street 436, Roeville, USA",
         "dropoff": "Richmond Street 535, Gracey, USA",
         "price": 22.61
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Eastern Parkway 914, Alleghenyville, USA",
         "dropoff": "Beach Place 988, Vandiver, USA",
         "price": 81.17
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Revere Place 910, Somerset, USA",
         "dropoff": "Kiely Place 783, Thomasville, USA",
         "price": 94.53
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bay Avenue 164, Lookingglass, USA",
         "dropoff": "Lee Avenue 828, Rosewood, USA",
         "price": 57.82
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Concord Street 646, Roderfield, USA",
         "dropoff": "Ditmars Street 145, Mulberry, USA",
         "price": 68.32
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Folsom Place 669, Loveland, USA",
         "dropoff": "Powers Street 511, Foxworth, USA",
         "price": 18.6
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Langham Street 169, Bayview, USA",
         "dropoff": "Stuyvesant Avenue 835, Talpa, USA",
         "price": 45.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Elton Street 920, Hartsville/Hartley, USA",
         "dropoff": "Frost Street 723, Rockingham, USA",
         "price": 91.31
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Vandervoort Place 408, Hemlock, USA",
         "dropoff": "Rockaway Avenue 78, Day, USA",
         "price": 52.1
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Mill Avenue 955, Choctaw, USA",
         "dropoff": "Ridge Boulevard 763, Ellerslie, USA",
         "price": 56.5
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Crosby Avenue 604, Advance, USA",
         "dropoff": "Dank Court 93, Hasty, USA",
         "price": 71.06
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lake Street 290, Deercroft, USA",
         "dropoff": "Campus Place 783, Tryon, USA",
         "price": 18.69
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Carroll Street 256, Eastvale, USA",
         "dropoff": "Elm Avenue 527, Southmont, USA",
         "price": 93.13
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Garfield Place 889, Roulette, USA",
         "dropoff": "Balfour Place 130, Williams, USA",
         "price": 10.92
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Crown Street 537, Hondah, USA",
         "dropoff": "Fay Court 762, Vicksburg, USA",
         "price": 49.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hanover Place 972, Cochranville, USA",
         "dropoff": "Howard Place 960, Chloride, USA",
         "price": 80.5
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bowery Street 355, Hailesboro, USA",
         "dropoff": "Whitwell Place 296, Otranto, USA",
         "price": 98.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Nautilus Avenue 103, Wheaton, USA",
         "dropoff": "Brightwater Court 973, Bainbridge, USA",
         "price": 98.63
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Anchorage Place 158, Oneida, USA",
         "dropoff": "Ryder Avenue 608, Heil, USA",
         "price": 18.4
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Plaza Street 456, Yardville, USA",
         "dropoff": "Montgomery Place 135, Indio, USA",
         "price": 75.44
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Centre Street 504, Cartwright, USA",
         "dropoff": "Kensington Walk 683, Yorklyn, USA",
         "price": 36.58
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Brooklyn Road 610, Dundee, USA",
         "dropoff": "Bergen Court 748, Sandston, USA",
         "price": 19.91
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bouck Court 255, Dana, USA",
         "dropoff": "Beayer Place 70, Sunbury, USA",
         "price": 15.52
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bond Street 682, Kenwood, USA",
         "dropoff": "Williams Court 9, Konterra, USA",
         "price": 40.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cozine Avenue 107, Carlos, USA",
         "dropoff": "Doone Court 625, Wawona, USA",
         "price": 62.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lake Avenue 79, Hobucken, USA",
         "dropoff": "Hudson Avenue 335, Rivereno, USA",
         "price": 18.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Independence Avenue 402, Catharine, USA",
         "dropoff": "Church Lane 70, Longbranch, USA",
         "price": 18.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gallatin Place 442, Murillo, USA",
         "dropoff": "Lawrence Avenue 499, Richville, USA",
         "price": 75.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Front Street 728, Winfred, USA",
         "dropoff": "Bliss Terrace 374, Coalmont, USA",
         "price": 51.52
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hewes Street 630, Blue, USA",
         "dropoff": "Lexington Avenue 551, Lafferty, USA",
         "price": 58.24
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Holmes Lane 21, Cliff, USA",
         "dropoff": "Kings Place 62, Neibert, USA",
         "price": 15.49
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Herkimer Place 948, Collins, USA",
         "dropoff": "Harbor Lane 226, Brenton, USA",
         "price": 17.41
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Perry Terrace 589, Deputy, USA",
         "dropoff": "Himrod Street 174, Woodlands, USA",
         "price": 26.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dekalb Avenue 142, Hall, USA",
         "dropoff": "Wolf Place 589, Bartonsville, USA",
         "price": 75.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Randolph Street 253, Salunga, USA",
         "dropoff": "Royce Street 501, Stockdale, USA",
         "price": 32.08
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Verona Street 163, Bowie, USA",
         "dropoff": "Vanderbilt Avenue 220, Hickory, USA",
         "price": 27.67
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Denton Place 562, Fingerville, USA",
         "dropoff": "Thomas Street 551, Cutter, USA",
         "price": 28.1
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fair Street 796, Savannah, USA",
         "dropoff": "Bancroft Place 280, Trail, USA",
         "price": 23.97
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sedgwick Place 103, Goodville, USA",
         "dropoff": "Polhemus Place 310, Ahwahnee, USA",
         "price": 21.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Leonard Street 946, Tivoli, USA",
         "dropoff": "Woodbine Street 585, Remington, USA",
         "price": 41.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Logan Street 978, Cedarville, USA",
         "dropoff": "River Street 201, Rehrersburg, USA",
         "price": 27.89
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hamilton Avenue 953, Bloomington, USA",
         "dropoff": "Thames Street 700, Dorneyville, USA",
         "price": 21.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Conduit Boulevard 408, Kersey, USA",
         "dropoff": "Elmwood Avenue 1000, Cavalero, USA",
         "price": 74.82
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Madoc Avenue 351, Lewis, USA",
         "dropoff": "Poplar Avenue 514, Wintersburg, USA",
         "price": 23.24
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bedford Avenue 615, Idamay, USA",
         "dropoff": "Jamaica Avenue 400, Nescatunga, USA",
         "price": 31.02
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cook Street 284, Darrtown, USA",
         "dropoff": "Glenwood Road 1, Bellfountain, USA",
         "price": 89.27
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lawrence Street 575, Herald, USA",
         "dropoff": "Poly Place 978, Mappsville, USA",
         "price": 44.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fairview Place 986, Gibbsville, USA",
         "dropoff": "Stryker Street 35, Malo, USA",
         "price": 47.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rutledge Street 911, Siglerville, USA",
         "dropoff": "Kenmore Terrace 649, Lupton, USA",
         "price": 55.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Garden Place 950, Vincent, USA",
         "dropoff": "Chestnut Avenue 104, Wescosville, USA",
         "price": 70.35
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Liberty Avenue 103, Englevale, USA",
         "dropoff": "Beekman Place 147, Bascom, USA",
         "price": 29.31
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Schaefer Street 739, Gibsonia, USA",
         "dropoff": "Sandford Street 335, Maury, USA",
         "price": 10.17
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Diamond Street 943, Steinhatchee, USA",
         "dropoff": "Bragg Court 515, Camptown, USA",
         "price": 73.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Farragut Place 386, Keller, USA",
         "dropoff": "Troy Avenue 741, Warren, USA",
         "price": 75.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dikeman Street 402, Singer, USA",
         "dropoff": "Henderson Walk 154, Martell, USA",
         "price": 62.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Empire Boulevard 667, Vowinckel, USA",
         "dropoff": "Kane Place 159, Eureka, USA",
         "price": 57.01
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Covert Street 736, Cawood, USA",
         "dropoff": "Poplar Street 314, Boomer, USA",
         "price": 55.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bedell Lane 715, Marenisco, USA",
         "dropoff": "Dennett Place 809, Mapletown, USA",
         "price": 32.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Christopher Avenue 504, Oley, USA",
         "dropoff": "Heath Place 459, Barronett, USA",
         "price": 34.13
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Madeline Court 224, Edneyville, USA",
         "dropoff": "Degraw Street 278, Kula, USA",
         "price": 75.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bay Parkway 356, Marshall, USA",
         "dropoff": "Schenectady Avenue 522, Bellamy, USA",
         "price": 25.55
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Channel Avenue 733, Roland, USA",
         "dropoff": "Newton Street 283, Lopezo, USA",
         "price": 24.5
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Auburn Place 815, Lorraine, USA",
         "dropoff": "Locust Avenue 824, Campo, USA",
         "price": 90.62
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Osborn Street 412, Matthews, USA",
         "dropoff": "Boynton Place 312, Sattley, USA",
         "price": 42.67
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Mersereau Court 671, Fairforest, USA",
         "dropoff": "Taaffe Place 161, Coyote, USA",
         "price": 80.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kingsway Place 304, Stouchsburg, USA",
         "dropoff": "Bushwick Avenue 649, Washington, USA",
         "price": 89.01
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seba Avenue 783, Yogaville, USA",
         "dropoff": "Saratoga Avenue 739, Garnet, USA",
         "price": 47.18
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bijou Avenue 278, Allendale, USA",
         "dropoff": "Evergreen Avenue 39, Ypsilanti, USA",
         "price": 41.86
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Irving Avenue 640, Sultana, USA",
         "dropoff": "Story Court 293, Soudan, USA",
         "price": 77.1
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Amber Street 884, Buxton, USA",
         "dropoff": "Jamison Lane 843, Whitmer, USA",
         "price": 92.34
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Borinquen Pl 850, Hiko, USA",
         "dropoff": "McKibbin Street 495, Moscow, USA",
         "price": 57.74
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Court Square 412, Lemoyne, USA",
         "dropoff": "Fillmore Avenue 806, Eagleville, USA",
         "price": 53.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lincoln Road 875, Soham, USA",
         "dropoff": "Furman Street 771, Harold, USA",
         "price": 41.86
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Woodhull Street 432, Naomi, USA",
         "dropoff": "Withers Street 1000, Grayhawk, USA",
         "price": 73.51
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Manor Court 417, Ryderwood, USA",
         "dropoff": "Lloyd Street 762, Crown, USA",
         "price": 78.97
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kenmore Court 844, Imperial, USA",
         "dropoff": "Vermont Street 109, Hiwasse, USA",
         "price": 22.55
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Pulaski Street 174, Joes, USA",
         "dropoff": "Hutchinson Court 994, Brecon, USA",
         "price": 82.7
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seigel Court 722, Beaverdale, USA",
         "dropoff": "Sutton Street 124, Belvoir, USA",
         "price": 67
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kingston Avenue 978, Cecilia, USA",
         "dropoff": "Woodrow Court 124, Linwood, USA",
         "price": 71.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seton Place 664, Courtland, USA",
         "dropoff": "Stoddard Place 372, Manchester, USA",
         "price": 72.39
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Argyle Road 896, Vale, USA",
         "dropoff": "Columbus Place 581, Finzel, USA",
         "price": 73.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Locust Street 161, Canby, USA",
         "dropoff": "Norman Avenue 580, Cornfields, USA",
         "price": 68.86
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Canton Court 627, Sehili, USA",
         "dropoff": "Hicks Street 310, Dunlo, USA",
         "price": 47.86
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Remsen Street 317, Ilchester, USA",
         "dropoff": "Beaver Street 31, Cucumber, USA",
         "price": 74.37
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ridge Court 117, Madrid, USA",
         "dropoff": "Fleet Street 119, Fostoria, USA",
         "price": 77.6
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Schweikerts Walk 126, Jardine, USA",
         "dropoff": "Milford Street 930, Kaka, USA",
         "price": 47.89
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Huntington Street 78, Stollings, USA",
         "dropoff": "Jackson Court 787, Evergreen, USA",
         "price": 35.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Meeker Avenue 713, Stevens, USA",
         "dropoff": "Fillmore Place 838, Garfield, USA",
         "price": 29.02
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Garden Street 999, Sussex, USA",
         "dropoff": "Canarsie Road 163, Cherokee, USA",
         "price": 22.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Canda Avenue 535, Sanford, USA",
         "dropoff": "Laurel Avenue 881, Summerfield, USA",
         "price": 45.7
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fanchon Place 383, Ezel, USA",
         "dropoff": "Knickerbocker Avenue 390, Blodgett, USA",
         "price": 29.44
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ridgewood Place 35, Churchill, USA",
         "dropoff": "Dorchester Road 521, Tyhee, USA",
         "price": 74.3
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Tabor Court 981, Derwood, USA",
         "dropoff": "Newkirk Avenue 196, Marysville, USA",
         "price": 15.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Colonial Road 44, Allamuchy, USA",
         "dropoff": "Pioneer Street 930, Glenbrook, USA",
         "price": 62.93
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Erasmus Street 893, Farmington, USA",
         "dropoff": "Llama Court 587, Balm, USA",
         "price": 31.13
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lott Avenue 764, Lumberton, USA",
         "dropoff": "Roder Avenue 232, Clara, USA",
         "price": 31.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lewis Place 176, Gordon, USA",
         "dropoff": "Seagate Avenue 184, Frank, USA",
         "price": 66.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seeley Street 250, Shrewsbury, USA",
         "dropoff": "Guider Avenue 957, Cassel, USA",
         "price": 97.55
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Allen Avenue 522, Cuylerville, USA",
         "dropoff": "Varick Avenue 230, Chestnut, USA",
         "price": 33.42
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fuller Place 897, Dyckesville, USA",
         "dropoff": "Howard Alley 662, Brantleyville, USA",
         "price": 81.24
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Jewel Street 94, Morgandale, USA",
         "dropoff": "Wilson Avenue 597, Hollins, USA",
         "price": 47.43
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Huron Street 586, Adelino, USA",
         "dropoff": "Ralph Avenue 741, Trexlertown, USA",
         "price": 37.75
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rapelye Street 450, Aurora, USA",
         "dropoff": "Nevins Street 323, Dunnavant, USA",
         "price": 24.63
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Nostrand Avenue 464, Unionville, USA",
         "dropoff": "Kathleen Court 693, Harborton, USA",
         "price": 45.77
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Middagh Street 239, Gallina, USA",
         "dropoff": "Cumberland Walk 375, Wright, USA",
         "price": 81.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fountain Avenue 761, Deseret, USA",
         "dropoff": "Miami Court 759, Chical, USA",
         "price": 75.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Macon Street 608, Kapowsin, USA",
         "dropoff": "Nolans Lane 684, Stewart, USA",
         "price": 87.26
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Tompkins Place 295, Elbert, USA",
         "dropoff": "Highland Avenue 130, Longoria, USA",
         "price": 88.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Morgan Avenue 263, Marion, USA",
         "dropoff": "Everit Street 441, Chesterfield, USA",
         "price": 91.28
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Varanda Place 537, Delwood, USA",
         "dropoff": "Clinton Street 257, Navarre, USA",
         "price": 87.58
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "McKibben Street 85, Snelling, USA",
         "dropoff": "Midwood Street 70, Grenelefe, USA",
         "price": 68.48
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hale Avenue 316, Brookfield, USA",
         "dropoff": "Highland Place 357, Haena, USA",
         "price": 91.06
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dwight Street 448, Terlingua, USA",
         "dropoff": "Batchelder Street 609, Romeville, USA",
         "price": 15.72
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Madison Street 234, Bentonville, USA",
         "dropoff": "Just Court 810, Woodruff, USA",
         "price": 69.78
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ferry Place 736, Morriston, USA",
         "dropoff": "Jerome Street 45, Russellville, USA",
         "price": 14.06
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Graham Avenue 622, Olney, USA",
         "dropoff": "Hampton Place 221, Coaldale, USA",
         "price": 92.27
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ide Court 977, Corriganville, USA",
         "dropoff": "Irving Street 520, Winston, USA",
         "price": 98.3
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Garland Court 714, Keyport, USA",
         "dropoff": "Montieth Street 56, Abrams, USA",
         "price": 21.35
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hampton Avenue 106, Clarence, USA",
         "dropoff": "Brightwater Avenue 330, Freelandville, USA",
         "price": 57.34
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Green Street 432, Lavalette, USA",
         "dropoff": "Dodworth Street 683, Gerton, USA",
         "price": 10.43
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Brown Street 692, Abiquiu, USA",
         "dropoff": "Stillwell Place 485, Orick, USA",
         "price": 49.55
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dover Street 64, Yettem, USA",
         "dropoff": "Willoughby Avenue 397, Stockwell, USA",
         "price": 67.41
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Union Street 302, Greenwich, USA",
         "dropoff": "Wythe Place 381, Greenfields, USA",
         "price": 76.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kingsland Avenue 328, Leola, USA",
         "dropoff": "Halleck Street 357, Websterville, USA",
         "price": 40.73
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Senator Street 293, Dixie, USA",
         "dropoff": "Havemeyer Street 367, Southview, USA",
         "price": 42.63
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Irvington Place 697, Stagecoach, USA",
         "dropoff": "Norfolk Street 321, Oasis, USA",
         "price": 39.36
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Irwin Street 348, Yukon, USA",
         "dropoff": "Driggs Avenue 898, Aberdeen, USA",
         "price": 66.75
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lorraine Street 450, Basye, USA",
         "dropoff": "Vanderveer Place 968, Bradenville, USA",
         "price": 19.23
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Monaco Place 412, Nadine, USA",
         "dropoff": "Navy Street 433, Escondida, USA",
         "price": 96.6
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Louisa Street 11, Como, USA",
         "dropoff": "Cleveland Street 687, Wauhillau, USA",
         "price": 70.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ruby Street 152, Weedville, USA",
         "dropoff": "Bartlett Place 566, Matheny, USA",
         "price": 23.77
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Delmonico Place 205, Dowling, USA",
         "dropoff": "Alabama Avenue 377, Ona, USA",
         "price": 90.77
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Miller Avenue 674, Croom, USA",
         "dropoff": "Oakland Place 858, Tibbie, USA",
         "price": 36.47
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Alice Court 148, Seymour, USA",
         "dropoff": "Interborough Parkway 167, Osmond, USA",
         "price": 64.68
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cortelyou Road 917, Homeworth, USA",
         "dropoff": "Corbin Place 105, Baden, USA",
         "price": 13.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sackman Street 764, Madaket, USA",
         "dropoff": "Butler Street 736, Walland, USA",
         "price": 96.79
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Gerritsen Avenue 320, Caron, USA",
         "dropoff": "Celeste Court 812, Hamilton, USA",
         "price": 21.48
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Vermont Court 867, Celeryville, USA",
         "dropoff": "Beard Street 613, Layhill, USA",
         "price": 64.57
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Java Street 682, Berwind, USA",
         "dropoff": "Rodney Street 553, Fairacres, USA",
         "price": 76.67
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cambridge Place 291, Sexton, USA",
         "dropoff": "Rost Place 887, Wyano, USA",
         "price": 54.52
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Charles Place 607, Sylvanite, USA",
         "dropoff": "Buffalo Avenue 418, Glasgow, USA",
         "price": 55.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Eldert Street 637, Rodanthe, USA",
         "dropoff": "George Street 85, Whipholt, USA",
         "price": 85.85
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Conover Street 147, Fredericktown, USA",
         "dropoff": "Baughman Place 410, Babb, USA",
         "price": 62.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Durland Place 846, Galesville, USA",
         "dropoff": "Harrison Place 873, Gorst, USA",
         "price": 44.15
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Alton Place 358, Flintville, USA",
         "dropoff": "Lewis Avenue 670, Tilleda, USA",
         "price": 17.7
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Veronica Place 619, Bedias, USA",
         "dropoff": "Thatford Avenue 394, Clarksburg, USA",
         "price": 57.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Garnet Street 102, Hanover, USA",
         "dropoff": "Schenck Avenue 194, Freeburn, USA",
         "price": 66.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hendrickson Place 414, Coinjock, USA",
         "dropoff": "Coffey Street 853, Falmouth, USA",
         "price": 74.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Schermerhorn Street 619, Waiohinu, USA",
         "dropoff": "Chester Street 912, Bladensburg, USA",
         "price": 48.69
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cadman Plaza 450, Juarez, USA",
         "dropoff": "Wolcott Street 54, Caroleen, USA",
         "price": 87.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Powell Street 731, Cowiche, USA",
         "dropoff": "Porter Avenue 680, Defiance, USA",
         "price": 52.79
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dekoven Court 345, Moquino, USA",
         "dropoff": "Montauk Court 591, Crumpler, USA",
         "price": 36.13
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Chester Avenue 492, Kohatk, USA",
         "dropoff": "Paerdegat Avenue 571, Sugartown, USA",
         "price": 53.14
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Raleigh Place 156, Clayville, USA",
         "dropoff": "Lincoln Place 202, Fedora, USA",
         "price": 66.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Harrison Avenue 114, Trona, USA",
         "dropoff": "Bedford Place 89, Felt, USA",
         "price": 94.91
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cooper Street 177, Homeland, USA",
         "dropoff": "Manhattan Avenue 206, Worton, USA",
         "price": 40.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Harway Avenue 443, Helen, USA",
         "dropoff": "Essex Street 216, Dixonville, USA",
         "price": 36.3
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bushwick Place 804, Boling, USA",
         "dropoff": "Livonia Avenue 615, Rosedale, USA",
         "price": 40.59
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Wogan Terrace 712, Welda, USA",
         "dropoff": "Stewart Street 352, Cotopaxi, USA",
         "price": 24.16
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Orange Street 776, Cobbtown, USA",
         "dropoff": "Tudor Terrace 424, Glenshaw, USA",
         "price": 36.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sunnyside Court 854, Caberfae, USA",
         "dropoff": "Butler Place 186, Venice, USA",
         "price": 60.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Carlton Avenue 529, Robinette, USA",
         "dropoff": "Stockton Street 352, Coventry, USA",
         "price": 17.37
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Troutman Street 179, Foscoe, USA",
         "dropoff": "Ross Street 79, Neahkahnie, USA",
         "price": 13.79
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Conklin Avenue 580, Silkworth, USA",
         "dropoff": "Vandervoort Avenue 405, Fairfield, USA",
         "price": 45.44
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ainslie Street 749, Carlton, USA",
         "dropoff": "Tampa Court 249, Duryea, USA",
         "price": 50.96
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hoyt Street 226, Dargan, USA",
         "dropoff": "Vine Street 513, Manila, USA",
         "price": 52.93
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Emerald Street 566, Fannett, USA",
         "dropoff": "Grant Avenue 278, Eastmont, USA",
         "price": 42.95
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bergen Street 606, Dodge, USA",
         "dropoff": "Amersfort Place 102, Leroy, USA",
         "price": 68.81
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Richards Street 265, Tedrow, USA",
         "dropoff": "Grimes Road 466, Riegelwood, USA",
         "price": 46.83
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Everett Avenue 124, Glenville, USA",
         "dropoff": "Matthews Court 410, Harleigh, USA",
         "price": 44.89
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kosciusko Street 843, Salix, USA",
         "dropoff": "Imlay Street 542, Woodlake, USA",
         "price": 99.99
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bridge Street 602, Vallonia, USA",
         "dropoff": "Knight Court 337, Davenport, USA",
         "price": 26.17
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bergen Place 129, Ticonderoga, USA",
         "dropoff": "Adams Street 577, Tilden, USA",
         "price": 56.77
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Maple Street 584, Cornucopia, USA",
         "dropoff": "Cheever Place 18, Columbus, USA",
         "price": 46.08
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lake Place 437, Sedley, USA",
         "dropoff": "Eagle Street 241, Trinway, USA",
         "price": 74.69
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Beverly Road 137, Kirk, USA",
         "dropoff": "Coyle Street 355, Lydia, USA",
         "price": 97.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cooke Court 318, Caspar, USA",
         "dropoff": "Mill Lane 741, Biehle, USA",
         "price": 92.53
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Berry Street 104, Masthope, USA",
         "dropoff": "Terrace Place 711, Clarktown, USA",
         "price": 94.47
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Windsor Place 973, Saranap, USA",
         "dropoff": "Riverdale Avenue 862, Garberville, USA",
         "price": 28.86
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rock Street 445, Hampstead, USA",
         "dropoff": "Pooles Lane 729, Gouglersville, USA",
         "price": 12.99
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Onderdonk Avenue 630, Jacksonwald, USA",
         "dropoff": "Oliver Street 478, Ribera, USA",
         "price": 32.77
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Beadel Street 377, Ivanhoe, USA",
         "dropoff": "Johnson Avenue 405, Hardyville, USA",
         "price": 63.17
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Granite Street 903, Waukeenah, USA",
         "dropoff": "Hegeman Avenue 265, Slovan, USA",
         "price": 11.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sullivan Street 455, Savage, USA",
         "dropoff": "Clara Street 592, Chaparrito, USA",
         "price": 83.71
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Blake Court 501, Sanborn, USA",
         "dropoff": "Berkeley Place 696, Titanic, USA",
         "price": 83.8
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Scholes Street 407, Staples, USA",
         "dropoff": "Oriental Boulevard 185, Sterling, USA",
         "price": 48.08
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Elizabeth Place 978, Hoehne, USA",
         "dropoff": "Creamer Street 954, Belgreen, USA",
         "price": 29.68
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cypress Court 824, Joppa, USA",
         "dropoff": "Tillary Street 228, Roy, USA",
         "price": 90.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Harkness Avenue 823, Benson, USA",
         "dropoff": "Waldane Court 912, Bannock, USA",
         "price": 68.18
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Beverley Road 470, Kanauga, USA",
         "dropoff": "Greenpoint Avenue 268, Nipinnawasee, USA",
         "price": 86.49
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Grace Court 890, Muse, USA",
         "dropoff": "Taylor Street 67, Cresaptown, USA",
         "price": 95.02
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Falmouth Street 207, Florence, USA",
         "dropoff": "Hancock Street 601, Bluffview, USA",
         "price": 96.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Noel Avenue 215, Kenmar, USA",
         "dropoff": "Macdougal Street 785, Datil, USA",
         "price": 82.29
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cropsey Avenue 723, Jessie, USA",
         "dropoff": "Luquer Street 929, Utting, USA",
         "price": 87.22
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kossuth Place 281, Wilmington, USA",
         "dropoff": "Clermont Avenue 515, Mooresburg, USA",
         "price": 64.07
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cherry Street 582, Walton, USA",
         "dropoff": "Crescent Street 255, Henrietta, USA",
         "price": 90.72
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Moultrie Street 472, Germanton, USA",
         "dropoff": "Prince Street 767, Dola, USA",
         "price": 70.83
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Pierrepont Street 875, Jamestown, USA",
         "dropoff": "Neptune Court 137, Fruitdale, USA",
         "price": 23.54
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bayard Street 140, Kent, USA",
         "dropoff": "Jay Street 108, Logan, USA",
         "price": 66.41
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Cameron Court 39, Springhill, USA",
         "dropoff": "Atkins Avenue 261, Hendersonville, USA",
         "price": 20.55
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Bay Street 168, Edinburg, USA",
         "dropoff": "Turner Place 129, Wacissa, USA",
         "price": 32.75
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Knapp Street 448, Dalton, USA",
         "dropoff": "Throop Avenue 467, Darbydale, USA",
         "price": 36.35
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Division Place 278, Calverton, USA",
         "dropoff": "Oak Street 771, Makena, USA",
         "price": 68.76
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Schroeders Avenue 428, Weeksville, USA",
         "dropoff": "Friel Place 125, Martinsville, USA",
         "price": 93.71
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lamont Court 822, Brooktrails, USA",
         "dropoff": "Bath Avenue 747, Falconaire, USA",
         "price": 42.58
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Woodruff Avenue 391, Why, USA",
         "dropoff": "Menahan Street 314, Camas, USA",
         "price": 71.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Vanderbilt Street 660, Shelby, USA",
         "dropoff": "Indiana Place 722, Cressey, USA",
         "price": 25.14
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Moore Street 148, Cliffside, USA",
         "dropoff": "Harden Street 770, Westwood, USA",
         "price": 54.66
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Boerum Street 441, Chautauqua, USA",
         "dropoff": "Court Street 943, Caledonia, USA",
         "price": 54.74
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Stillwell Avenue 854, Lawrence, USA",
         "dropoff": "Brighton Court 711, Holtville, USA",
         "price": 86.42
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Kay Court 644, Waikele, USA",
         "dropoff": "Montana Place 617, Chamberino, USA",
         "price": 37.21
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Coleman Street 855, Klagetoh, USA",
         "dropoff": "Turnbull Avenue 245, Townsend, USA",
         "price": 94.78
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Prospect Place 600, Mansfield, USA",
         "dropoff": "Strickland Avenue 489, Watrous, USA",
         "price": 95.83
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Tompkins Avenue 60, Accoville, USA",
         "dropoff": "Herzl Street 763, Kraemer, USA",
         "price": 46.34
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Arlington Place 746, Mammoth, USA",
         "dropoff": "Shale Street 4, Austinburg, USA",
         "price": 26.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seacoast Terrace 283, Virgie, USA",
         "dropoff": "Royce Place 435, Faxon, USA",
         "price": 33.26
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hunterfly Place 593, Belmont, USA",
         "dropoff": "Rutherford Place 594, Fairhaven, USA",
         "price": 29.41
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Clinton Avenue 357, Turah, USA",
         "dropoff": "Baycliff Terrace 447, Bartley, USA",
         "price": 13.91
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Mayfair Drive 885, Grahamtown, USA",
         "dropoff": "Clove Road 591, Zortman, USA",
         "price": 74.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "President Street 70, Norfolk, USA",
         "dropoff": "Malbone Street 645, Blanco, USA",
         "price": 35.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Division Avenue 91, Thynedale, USA",
         "dropoff": "Stuart Street 718, Dexter, USA",
         "price": 69.65
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ovington Court 515, Disautel, USA",
         "dropoff": "Reeve Place 349, Gulf, USA",
         "price": 19.77
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Applegate Court 942, Epworth, USA",
         "dropoff": "Jaffray Street 286, Holcombe, USA",
         "price": 23.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Downing Street 762, Montura, USA",
         "dropoff": "Linwood Street 301, Chamizal, USA",
         "price": 25.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Williamsburg Street 161, Worcester, USA",
         "dropoff": "Brooklyn Avenue 241, Hoagland, USA",
         "price": 17.14
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Williams Avenue 856, Carbonville, USA",
         "dropoff": "Lawton Street 584, Alfarata, USA",
         "price": 58.69
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dunne Court 124, Elfrida, USA",
         "dropoff": "Ocean Avenue 645, Windsor, USA",
         "price": 30.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Seaview Court 415, Cazadero, USA",
         "dropoff": "Monument Walk 270, Outlook, USA",
         "price": 23.91
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Delevan Street 856, Sena, USA",
         "dropoff": "Kent Avenue 16, Topaz, USA",
         "price": 91.99
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Quentin Street 584, Charco, USA",
         "dropoff": "Townsend Street 264, Ripley, USA",
         "price": 85.05
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Arlington Avenue 768, Fowlerville, USA",
         "dropoff": "Tapscott Street 999, Shasta, USA",
         "price": 61.76
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "College Place 601, Alderpoint, USA",
         "dropoff": "Stone Avenue 323, Jeff, USA",
         "price": 50.74
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Rockaway Parkway 832, Veguita, USA",
         "dropoff": "Hornell Loop 211, Hessville, USA",
         "price": 56.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Melba Court 95, Durham, USA",
         "dropoff": "Fane Court 584, Springdale, USA",
         "price": 73.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Jodie Court 429, Starks, USA",
         "dropoff": "Preston Court 133, Laurelton, USA",
         "price": 87.32
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Campus Road 84, Wollochet, USA",
         "dropoff": "Classon Avenue 767, Coldiron, USA",
         "price": 86.72
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Juliana Place 743, Bethany, USA",
         "dropoff": "Columbia Place 264, Belleview, USA",
         "price": 18.4
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Utica Avenue 459, Boonville, USA",
         "dropoff": "Willow Place 333, Independence, USA",
         "price": 14.25
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Holly Street 948, Loretto, USA",
         "dropoff": "Rugby Road 708, Condon, USA",
         "price": 68.72
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Irving Place 498, Lindcove, USA",
         "dropoff": "Radde Place 15, Hannasville, USA",
         "price": 70.44
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Pacific Street 455, Dragoon, USA",
         "dropoff": "Seaview Avenue 265, Morningside, USA",
         "price": 15.96
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Whitney Avenue 509, Sunwest, USA",
         "dropoff": "Lenox Road 523, Ronco, USA",
         "price": 63.38
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Exeter Street 260, Norvelt, USA",
         "dropoff": "Johnson Street 42, Kidder, USA",
         "price": 10.38
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Ocean Parkway 69, Magnolia, USA",
         "dropoff": "Wyckoff Avenue 985, Strong, USA",
         "price": 11.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Otsego Street 426, Williamson, USA",
         "dropoff": "Brevoort Place 394, Elliston, USA",
         "price": 84.27
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hinsdale Street 112, Thornport, USA",
         "dropoff": "Victor Road 841, Efland, USA",
         "price": 17.44
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Narrows Avenue 680, Crucible, USA",
         "dropoff": "Ashford Street 836, Adamstown, USA",
         "price": 47.38
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Greene Avenue 423, Oretta, USA",
         "dropoff": "Montague Terrace 824, Fresno, USA",
         "price": 85.97
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Clymer Street 26, Brewster, USA",
         "dropoff": "Tilden Avenue 616, Rew, USA",
         "price": 60.11
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Woodpoint Road 701, Lowell, USA",
         "dropoff": "Willmohr Street 337, Maybell, USA",
         "price": 56.8
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Eldert Lane 610, Innsbrook, USA",
         "dropoff": "Overbaugh Place 779, Needmore, USA",
         "price": 72.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Billings Place 166, Nettie, USA",
         "dropoff": "Loring Avenue 992, Berlin, USA",
         "price": 13.43
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Love Lane 553, Bourg, USA",
         "dropoff": "Linden Boulevard 82, Devon, USA",
         "price": 44
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Jardine Place 200, Beason, USA",
         "dropoff": "Ryerson Street 432, Summerset, USA",
         "price": 50.33
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Chestnut Street 41, Kempton, USA",
         "dropoff": "Ivan Court 338, Elrama, USA",
         "price": 54.39
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Little Street 983, Lund, USA",
         "dropoff": "Cobek Court 327, Levant, USA",
         "price": 65.94
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Barlow Drive 553, Jugtown, USA",
         "dropoff": "Bevy Court 194, Bethpage, USA",
         "price": 69.04
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Varet Street 813, Calvary, USA",
         "dropoff": "Nassau Avenue 740, Stonybrook, USA",
         "price": 90.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Duffield Street 914, Ironton, USA",
         "dropoff": "Marconi Place 262, Caroline, USA",
         "price": 64.08
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Grand Avenue 567, Driftwood, USA",
         "dropoff": "Hawthorne Street 260, Lloyd, USA",
         "price": 73.79
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Fulton Street 303, Gila, USA",
         "dropoff": "Dahlgreen Place 519, Shaft, USA",
         "price": 21.82
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Newport Street 324, Brule, USA",
         "dropoff": "Devoe Street 774, Dupuyer, USA",
         "price": 74.69
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Wallabout Street 495, Chelsea, USA",
         "dropoff": "Brighton Avenue 977, Hackneyville, USA",
         "price": 59.04
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Sumner Place 298, Hegins, USA",
         "dropoff": "Estate Road 55, Homestead, USA",
         "price": 35.88
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Aviation Road 119, Greensburg, USA",
         "dropoff": "Cranberry Street 565, Emory, USA",
         "price": 34.93
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Merit Court 205, Waumandee, USA",
         "dropoff": "Bleecker Street 184, Wedgewood, USA",
         "price": 67.18
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Hyman Court 125, Santel, USA",
         "dropoff": "Maujer Street 153, Vernon, USA",
         "price": 30.49
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "McKinley Avenue 77, Sheatown, USA",
         "dropoff": "Lawn Court 66, Linganore, USA",
         "price": 32.37
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Church Avenue 812, Herbster, USA",
         "dropoff": "Montauk Avenue 74, Blandburg, USA",
         "price": 99.09
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Willoughby Street 329, Forestburg, USA",
         "dropoff": "Bainbridge Street 762, Westphalia, USA",
         "price": 84.67
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Vernon Avenue 331, Hilltop, USA",
         "dropoff": "Cox Place 547, Cannondale, USA",
         "price": 23.75
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Oriental Court 30, Martinez, USA",
         "dropoff": "Landis Court 83, Cade, USA",
         "price": 93.64
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Madison Place 99, Spelter, USA",
         "dropoff": "Russell Street 402, Dahlen, USA",
         "price": 29.8
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Dooley Street 341, Tuskahoma, USA",
         "dropoff": "Louise Terrace 101, Winchester, USA",
         "price": 17.12
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Colonial Court 135, Nicholson, USA",
         "dropoff": "Krier Place 303, Williston, USA",
         "price": 80.19
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Junius Street 681, Delco, USA",
         "dropoff": "Bennet Court 132, Manitou, USA",
         "price": 82.91
+      },
+      "message": {
+        "event": "RideCreated"
       }
     },
     {
       "log_level": "info",
-      "event": "RideCreated",
+      "event": "request_finished",
       "body": {
         "pickup": "Lefferts Place 142, Bakersville, USA",
         "dropoff": "Thornton Street 50, Harrodsburg, USA",
         "price": 81.2
+      },
+      "message": {
+        "event": "RideCreated"
       }
     }
   ]

--- a/data/success/ride-created.json
+++ b/data/success/ride-created.json
@@ -7,9 +7,7 @@
         "dropoff": "Remsen Avenue 973, Zarephath, USA",
         "price": 83.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -19,9 +17,7 @@
         "dropoff": "Lester Court 911, Grill, USA",
         "price": 99.93
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -31,9 +27,7 @@
         "dropoff": "Elliott Place 806, Orason, USA",
         "price": 64.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -43,9 +37,7 @@
         "dropoff": "Franklin Street 756, Hachita, USA",
         "price": 91.85
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -55,9 +47,7 @@
         "dropoff": "Conselyea Street 417, Byrnedale, USA",
         "price": 66.23
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -67,9 +57,7 @@
         "dropoff": "Noble Street 613, Barrelville, USA",
         "price": 23.42
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -79,9 +67,7 @@
         "dropoff": "Lorimer Street 777, Tonopah, USA",
         "price": 76.89
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -91,9 +77,7 @@
         "dropoff": "Mill Road 828, Goochland, USA",
         "price": 19.39
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -103,9 +87,7 @@
         "dropoff": "Bragg Street 702, Strykersville, USA",
         "price": 92.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -115,9 +97,7 @@
         "dropoff": "Meserole Avenue 266, Blanford, USA",
         "price": 41.78
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -127,9 +107,7 @@
         "dropoff": "Forrest Street 378, Hatteras, USA",
         "price": 50.63
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -139,9 +117,7 @@
         "dropoff": "Doscher Street 494, Bodega, USA",
         "price": 31.58
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -151,9 +127,7 @@
         "dropoff": "Gelston Avenue 705, Dunbar, USA",
         "price": 94.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -163,9 +137,7 @@
         "dropoff": "Clarendon Road 36, Grantville, USA",
         "price": 62.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -175,9 +147,7 @@
         "dropoff": "Wythe Avenue 110, Catherine, USA",
         "price": 23.59
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -187,9 +157,7 @@
         "dropoff": "Claver Place 958, Gorham, USA",
         "price": 31.39
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -199,9 +167,7 @@
         "dropoff": "Hazel Court 81, Newcastle, USA",
         "price": 34.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -211,9 +177,7 @@
         "dropoff": "Apollo Street 511, Nogal, USA",
         "price": 66.63
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -223,9 +187,7 @@
         "dropoff": "Oxford Walk 656, Drytown, USA",
         "price": 59.14
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -235,9 +197,7 @@
         "dropoff": "Fenimore Street 145, Canoochee, USA",
         "price": 82.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -247,9 +207,7 @@
         "dropoff": "Hall Street 931, Kimmell, USA",
         "price": 85.03
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -259,9 +217,7 @@
         "dropoff": "Ebony Court 679, Turpin, USA",
         "price": 69.14
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -271,9 +227,7 @@
         "dropoff": "Guernsey Street 987, Bendon, USA",
         "price": 95.58
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -283,9 +237,7 @@
         "dropoff": "Norwood Avenue 275, Bordelonville, USA",
         "price": 57.47
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -295,9 +247,7 @@
         "dropoff": "Scott Avenue 984, Libertytown, USA",
         "price": 47.16
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -307,9 +257,7 @@
         "dropoff": "Nassau Street 54, Jackpot, USA",
         "price": 41.48
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -319,9 +267,7 @@
         "dropoff": "Aster Court 634, Concho, USA",
         "price": 97.92
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -331,9 +277,7 @@
         "dropoff": "Visitation Place 546, Topanga, USA",
         "price": 77.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -343,9 +287,7 @@
         "dropoff": "Oceanic Avenue 316, Skyland, USA",
         "price": 15.63
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -355,9 +297,7 @@
         "dropoff": "Morton Street 512, Rockhill, USA",
         "price": 79.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -367,9 +307,7 @@
         "dropoff": "Gunnison Court 85, Smock, USA",
         "price": 68.82
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -379,9 +317,7 @@
         "dropoff": "Bartlett Street 607, Freetown, USA",
         "price": 49.62
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -391,9 +327,7 @@
         "dropoff": "McDonald Avenue 502, Drummond, USA",
         "price": 68.48
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -403,9 +337,7 @@
         "dropoff": "Virginia Place 980, Brandywine, USA",
         "price": 61.36
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -415,9 +347,7 @@
         "dropoff": "Kimball Street 890, Franklin, USA",
         "price": 82.27
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -427,9 +357,7 @@
         "dropoff": "Reed Street 450, Knowlton, USA",
         "price": 67.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -439,9 +367,7 @@
         "dropoff": "Sharon Street 643, Finderne, USA",
         "price": 22.99
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -451,9 +377,7 @@
         "dropoff": "Jerome Avenue 518, Cloverdale, USA",
         "price": 61.04
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -463,9 +387,7 @@
         "dropoff": "Dare Court 355, Volta, USA",
         "price": 30.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -475,9 +397,7 @@
         "dropoff": "Moffat Street 673, Gambrills, USA",
         "price": 99.49
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -487,9 +407,7 @@
         "dropoff": "Karweg Place 843, Fontanelle, USA",
         "price": 50.85
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -499,9 +417,7 @@
         "dropoff": "Pineapple Street 249, Machias, USA",
         "price": 89.21
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -511,9 +427,7 @@
         "dropoff": "Commerce Street 113, Golconda, USA",
         "price": 85.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -523,9 +437,7 @@
         "dropoff": "Martense Street 556, Bangor, USA",
         "price": 39.89
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -535,9 +447,7 @@
         "dropoff": "Mill Street 30, Callaghan, USA",
         "price": 77.9
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -547,9 +457,7 @@
         "dropoff": "Monitor Street 697, Bluetown, USA",
         "price": 59.34
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -559,9 +467,7 @@
         "dropoff": "Wortman Avenue 446, Bynum, USA",
         "price": 48.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -571,9 +477,7 @@
         "dropoff": "Highland Boulevard 490, Wanship, USA",
         "price": 27.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -583,9 +487,7 @@
         "dropoff": "Colby Court 784, Emison, USA",
         "price": 20.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -595,9 +497,7 @@
         "dropoff": "Highlawn Avenue 159, Retsof, USA",
         "price": 87.43
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -607,9 +507,7 @@
         "dropoff": "Fleet Place 819, Barstow, USA",
         "price": 58.16
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -619,9 +517,7 @@
         "dropoff": "Murdock Court 477, Newry, USA",
         "price": 57.92
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -631,9 +527,7 @@
         "dropoff": "Danforth Street 131, Geyserville, USA",
         "price": 46.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -643,9 +537,7 @@
         "dropoff": "Sutter Avenue 931, Corinne, USA",
         "price": 87.98
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -655,9 +547,7 @@
         "dropoff": "Olive Street 380, Waverly, USA",
         "price": 96.62
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -667,9 +557,7 @@
         "dropoff": "Crawford Avenue 515, Bend, USA",
         "price": 62.72
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -679,9 +567,7 @@
         "dropoff": "Trucklemans Lane 554, Nord, USA",
         "price": 74.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -691,9 +577,7 @@
         "dropoff": "Lincoln Avenue 652, Hinsdale, USA",
         "price": 18.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -703,9 +587,7 @@
         "dropoff": "Beacon Court 617, Kipp, USA",
         "price": 16.55
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -715,9 +597,7 @@
         "dropoff": "Legion Street 382, Edenburg, USA",
         "price": 87.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -727,9 +607,7 @@
         "dropoff": "Pitkin Avenue 744, Edgar, USA",
         "price": 79.73
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -739,9 +617,7 @@
         "dropoff": "Coles Street 217, Kerby, USA",
         "price": 91.74
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -751,9 +627,7 @@
         "dropoff": "Regent Place 514, Rowe, USA",
         "price": 66.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -763,9 +637,7 @@
         "dropoff": "Abbey Court 588, Convent, USA",
         "price": 63.42
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -775,9 +647,7 @@
         "dropoff": "Nova Court 441, Farmers, USA",
         "price": 65.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -787,9 +657,7 @@
         "dropoff": "Boulevard Court 324, Bancroft, USA",
         "price": 35.52
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -799,9 +667,7 @@
         "dropoff": "Dearborn Court 941, Orovada, USA",
         "price": 72.17
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -811,9 +677,7 @@
         "dropoff": "McClancy Place 272, Castleton, USA",
         "price": 75.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -823,9 +687,7 @@
         "dropoff": "School Lane 633, Gardiner, USA",
         "price": 55.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -835,9 +697,7 @@
         "dropoff": "Amboy Street 47, Chapin, USA",
         "price": 71.5
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -847,9 +707,7 @@
         "dropoff": "Veterans Avenue 445, Teasdale, USA",
         "price": 64.36
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -859,9 +717,7 @@
         "dropoff": "Opal Court 427, Vienna, USA",
         "price": 16.82
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -871,9 +727,7 @@
         "dropoff": "Portland Avenue 56, Kingstowne, USA",
         "price": 35.58
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -883,9 +737,7 @@
         "dropoff": "Meadow Street 93, Limestone, USA",
         "price": 21.42
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -895,9 +747,7 @@
         "dropoff": "Gaylord Drive 313, Deltaville, USA",
         "price": 92.45
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -907,9 +757,7 @@
         "dropoff": "Nichols Avenue 77, Chesapeake, USA",
         "price": 84.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -919,9 +767,7 @@
         "dropoff": "Prescott Place 706, Templeton, USA",
         "price": 86.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -931,9 +777,7 @@
         "dropoff": "Provost Street 783, Valmy, USA",
         "price": 73.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -943,9 +787,7 @@
         "dropoff": "Underhill Avenue 545, Nile, USA",
         "price": 83.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -955,9 +797,7 @@
         "dropoff": "Roebling Street 875, Iberia, USA",
         "price": 51.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -967,9 +807,7 @@
         "dropoff": "Amherst Street 333, Saticoy, USA",
         "price": 95.41
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -979,9 +817,7 @@
         "dropoff": "Rogers Avenue 19, Muir, USA",
         "price": 60.71
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -991,9 +827,7 @@
         "dropoff": "Tehama Street 96, Detroit, USA",
         "price": 12.3
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1003,9 +837,7 @@
         "dropoff": "Broome Street 935, Summertown, USA",
         "price": 80.07
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1015,9 +847,7 @@
         "dropoff": "Dorset Street 887, Watchtower, USA",
         "price": 98.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1027,9 +857,7 @@
         "dropoff": "Amity Street 493, Rose, USA",
         "price": 30.06
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1039,9 +867,7 @@
         "dropoff": "Clarkson Avenue 750, Kieler, USA",
         "price": 69.39
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1051,9 +877,7 @@
         "dropoff": "Hunts Lane 871, Riner, USA",
         "price": 34.57
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1063,9 +887,7 @@
         "dropoff": "Livingston Street 440, Spokane, USA",
         "price": 39.03
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1075,9 +897,7 @@
         "dropoff": "Judge Street 99, Itmann, USA",
         "price": 90.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1087,9 +907,7 @@
         "dropoff": "Jefferson Avenue 381, Elwood, USA",
         "price": 44.32
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1099,9 +917,7 @@
         "dropoff": "Prospect Avenue 342, Albany, USA",
         "price": 59.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1111,9 +927,7 @@
         "dropoff": "Ocean Court 932, Allison, USA",
         "price": 73.13
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1123,9 +937,7 @@
         "dropoff": "Banner Avenue 879, Ruckersville, USA",
         "price": 30.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1135,9 +947,7 @@
         "dropoff": "Prospect Street 889, Darlington, USA",
         "price": 48.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1147,9 +957,7 @@
         "dropoff": "Dumont Avenue 105, Statenville, USA",
         "price": 71.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1159,9 +967,7 @@
         "dropoff": "Belmont Avenue 688, Albrightsville, USA",
         "price": 53.31
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1171,9 +977,7 @@
         "dropoff": "Gotham Avenue 336, Tecolotito, USA",
         "price": 87.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1183,9 +987,7 @@
         "dropoff": "Williams Place 310, Grazierville, USA",
         "price": 36.48
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1195,9 +997,7 @@
         "dropoff": "Crooke Avenue 369, Ladera, USA",
         "price": 81.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1207,9 +1007,7 @@
         "dropoff": "Drew Street 802, Denio, USA",
         "price": 84.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1219,9 +1017,7 @@
         "dropoff": "Minna Street 610, Westerville, USA",
         "price": 14.07
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1231,9 +1027,7 @@
         "dropoff": "Dunham Place 91, Dennard, USA",
         "price": 35.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1243,9 +1037,7 @@
         "dropoff": "Dahl Court 868, Diaperville, USA",
         "price": 12.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1255,9 +1047,7 @@
         "dropoff": "Chester Court 981, Orin, USA",
         "price": 38.73
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1267,9 +1057,7 @@
         "dropoff": "Georgia Avenue 799, Enoree, USA",
         "price": 92.57
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1279,9 +1067,7 @@
         "dropoff": "Horace Court 1000, Weogufka, USA",
         "price": 23.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1291,9 +1077,7 @@
         "dropoff": "Linden Street 628, Sharon, USA",
         "price": 13.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1303,9 +1087,7 @@
         "dropoff": "Village Court 392, Thermal, USA",
         "price": 88.62
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1315,9 +1097,7 @@
         "dropoff": "Hubbard Place 606, Motley, USA",
         "price": 71.89
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1327,9 +1107,7 @@
         "dropoff": "Ovington Avenue 353, Harviell, USA",
         "price": 79.23
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1339,9 +1117,7 @@
         "dropoff": "Chase Court 159, Wiscon, USA",
         "price": 56.69
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1351,9 +1127,7 @@
         "dropoff": "Myrtle Avenue 886, Beyerville, USA",
         "price": 41.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1363,9 +1137,7 @@
         "dropoff": "Vandam Street 500, Monument, USA",
         "price": 33.86
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1375,9 +1147,7 @@
         "dropoff": "Rose Street 836, Wadsworth, USA",
         "price": 15.13
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1387,9 +1157,7 @@
         "dropoff": "Kensington Street 460, Kylertown, USA",
         "price": 20.15
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1399,9 +1167,7 @@
         "dropoff": "Forest Place 206, Bawcomville, USA",
         "price": 71.74
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1411,9 +1177,7 @@
         "dropoff": "Pershing Loop 383, Rutherford, USA",
         "price": 71.71
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1423,9 +1187,7 @@
         "dropoff": "Tennis Court 780, Ballico, USA",
         "price": 36.16
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1435,9 +1197,7 @@
         "dropoff": "Elm Place 931, Hollymead, USA",
         "price": 57.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1447,9 +1207,7 @@
         "dropoff": "Atlantic Avenue 59, Beechmont, USA",
         "price": 84.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1459,9 +1217,7 @@
         "dropoff": "Meserole Street 420, Grapeview, USA",
         "price": 45.57
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1471,9 +1227,7 @@
         "dropoff": "Vanderveer Street 644, Chalfant, USA",
         "price": 95.68
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1483,9 +1237,7 @@
         "dropoff": "Grattan Street 939, Vaughn, USA",
         "price": 68.6
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1495,9 +1247,7 @@
         "dropoff": "Quincy Street 790, Wildwood, USA",
         "price": 66.49
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1507,9 +1257,7 @@
         "dropoff": "Herkimer Street 977, Twilight, USA",
         "price": 58.55
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1519,9 +1267,7 @@
         "dropoff": "Metropolitan Avenue 412, Rote, USA",
         "price": 72.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1531,9 +1277,7 @@
         "dropoff": "Ryder Street 250, Leyner, USA",
         "price": 68.93
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1543,9 +1287,7 @@
         "dropoff": "Wyona Street 984, Canterwood, USA",
         "price": 76.08
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1555,9 +1297,7 @@
         "dropoff": "Dictum Court 518, Takilma, USA",
         "price": 91.52
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1567,9 +1307,7 @@
         "dropoff": "Sapphire Street 683, Brownlee, USA",
         "price": 47.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1579,9 +1317,7 @@
         "dropoff": "Lombardy Street 249, Odessa, USA",
         "price": 89.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1591,9 +1327,7 @@
         "dropoff": "Congress Street 239, Taft, USA",
         "price": 67.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1603,9 +1337,7 @@
         "dropoff": "Vandalia Avenue 222, Blairstown, USA",
         "price": 16.66
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1615,9 +1347,7 @@
         "dropoff": "Willow Street 822, Wilsonia, USA",
         "price": 77.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1627,9 +1357,7 @@
         "dropoff": "Moore Place 207, Cascades, USA",
         "price": 58.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1639,9 +1367,7 @@
         "dropoff": "Benson Avenue 37, Allentown, USA",
         "price": 93.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1651,9 +1377,7 @@
         "dropoff": "Boerum Place 189, Eggertsville, USA",
         "price": 46.68
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1663,9 +1387,7 @@
         "dropoff": "Fayette Street 675, Kansas, USA",
         "price": 94.38
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1675,9 +1397,7 @@
         "dropoff": "Gates Avenue 89, Robinson, USA",
         "price": 90.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1687,9 +1407,7 @@
         "dropoff": "Homecrest Court 910, Brethren, USA",
         "price": 93.46
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1699,9 +1417,7 @@
         "dropoff": "Kaufman Place 544, Harrison, USA",
         "price": 92.07
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1711,9 +1427,7 @@
         "dropoff": "Lancaster Avenue 544, Norwood, USA",
         "price": 38.32
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1723,9 +1437,7 @@
         "dropoff": "Lloyd Court 16, Floris, USA",
         "price": 14.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1735,9 +1447,7 @@
         "dropoff": "Arion Place 408, Rossmore, USA",
         "price": 73.18
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1747,9 +1457,7 @@
         "dropoff": "Duryea Place 511, Islandia, USA",
         "price": 23.83
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1759,9 +1467,7 @@
         "dropoff": "Haring Street 57, Crisman, USA",
         "price": 60.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1771,9 +1477,7 @@
         "dropoff": "Freeman Street 986, Fairview, USA",
         "price": 27.96
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1783,9 +1487,7 @@
         "dropoff": "Walker Court 65, Caln, USA",
         "price": 61.27
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1795,9 +1497,7 @@
         "dropoff": "Heyward Street 838, Snyderville, USA",
         "price": 38.85
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1807,9 +1507,7 @@
         "dropoff": "Evans Street 830, Marienthal, USA",
         "price": 88.5
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1819,9 +1517,7 @@
         "dropoff": "Douglass Street 218, Saddlebrooke, USA",
         "price": 11.76
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1831,9 +1527,7 @@
         "dropoff": "Lafayette Walk 551, Tioga, USA",
         "price": 72.92
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1843,9 +1537,7 @@
         "dropoff": "Belvidere Street 635, Marbury, USA",
         "price": 62.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1855,9 +1547,7 @@
         "dropoff": "Ford Street 974, Katonah, USA",
         "price": 66.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1867,9 +1557,7 @@
         "dropoff": "Glendale Court 746, Forbestown, USA",
         "price": 34.08
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1879,9 +1567,7 @@
         "dropoff": "Roosevelt Place 331, Enetai, USA",
         "price": 85.76
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1891,9 +1577,7 @@
         "dropoff": "Nixon Court 521, Inkerman, USA",
         "price": 61.16
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1903,9 +1587,7 @@
         "dropoff": "Calder Place 541, Clinton, USA",
         "price": 79.62
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1915,9 +1597,7 @@
         "dropoff": "Plymouth Street 144, Avalon, USA",
         "price": 32.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1927,9 +1607,7 @@
         "dropoff": "Broadway  157, Crenshaw, USA",
         "price": 10.62
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1939,9 +1617,7 @@
         "dropoff": "Bokee Court 316, Frierson, USA",
         "price": 86
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1951,9 +1627,7 @@
         "dropoff": "Bethel Loop 181, Brady, USA",
         "price": 62.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1963,9 +1637,7 @@
         "dropoff": "Hope Street 803, National, USA",
         "price": 58.83
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1975,9 +1647,7 @@
         "dropoff": "Hemlock Street 747, Sanders, USA",
         "price": 92.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1987,9 +1657,7 @@
         "dropoff": "Montague Street 612, Wakarusa, USA",
         "price": 68.46
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -1999,9 +1667,7 @@
         "dropoff": "Eckford Street 821, Cumberland, USA",
         "price": 34.3
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2011,9 +1677,7 @@
         "dropoff": "Lefferts Avenue 39, Gilmore, USA",
         "price": 25.26
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2023,9 +1687,7 @@
         "dropoff": "Flatlands Avenue 199, Nash, USA",
         "price": 78.38
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2035,9 +1697,7 @@
         "dropoff": "Union Avenue 294, Centerville, USA",
         "price": 87.14
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2047,9 +1707,7 @@
         "dropoff": "Herbert Street 245, Sisquoc, USA",
         "price": 12.4
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2059,9 +1717,7 @@
         "dropoff": "Louisiana Avenue 140, Rosine, USA",
         "price": 48.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2071,9 +1727,7 @@
         "dropoff": "Tech Place 723, Blackgum, USA",
         "price": 26.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2083,9 +1737,7 @@
         "dropoff": "King Street 492, Tyro, USA",
         "price": 62.57
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2095,9 +1747,7 @@
         "dropoff": "Debevoise Avenue 270, Conway, USA",
         "price": 72.07
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2107,9 +1757,7 @@
         "dropoff": "Newel Street 286, Fidelis, USA",
         "price": 32.73
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2119,9 +1767,7 @@
         "dropoff": "Village Road 874, Enlow, USA",
         "price": 15.83
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2131,9 +1777,7 @@
         "dropoff": "Albany Avenue 441, Biddle, USA",
         "price": 73.46
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2143,9 +1787,7 @@
         "dropoff": "Hastings Street 909, Coral, USA",
         "price": 80.8
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2155,9 +1797,7 @@
         "dropoff": "Times Placez 70, Thatcher, USA",
         "price": 43.93
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2167,9 +1807,7 @@
         "dropoff": "Wilson Street 723, Brogan, USA",
         "price": 25.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2179,9 +1817,7 @@
         "dropoff": "Coventry Road 492, Valle, USA",
         "price": 31.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2191,9 +1827,7 @@
         "dropoff": "Losee Terrace 249, Gardners, USA",
         "price": 21.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2203,9 +1837,7 @@
         "dropoff": "Strauss Street 928, Bowden, USA",
         "price": 57.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2215,9 +1847,7 @@
         "dropoff": "Chapel Street 309, Hiseville, USA",
         "price": 65.37
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2227,9 +1857,7 @@
         "dropoff": "Putnam Avenue 460, Sparkill, USA",
         "price": 34.6
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2239,9 +1867,7 @@
         "dropoff": "Pierrepont Place 2, Curtice, USA",
         "price": 90.37
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2251,9 +1877,7 @@
         "dropoff": "Dakota Place 973, Wakulla, USA",
         "price": 69.63
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2263,9 +1887,7 @@
         "dropoff": "Hausman Street 84, Waterford, USA",
         "price": 78.66
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2275,9 +1897,7 @@
         "dropoff": "Debevoise Street 400, Beaulieu, USA",
         "price": 78.01
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2287,9 +1907,7 @@
         "dropoff": "Ashland Place 615, Boykin, USA",
         "price": 49.96
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2299,9 +1917,7 @@
         "dropoff": "Dewitt Avenue 386, Nelson, USA",
         "price": 88.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2311,9 +1927,7 @@
         "dropoff": "Girard Street 125, Northchase, USA",
         "price": 30.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2323,9 +1937,7 @@
         "dropoff": "Gem Street 808, Carrizo, USA",
         "price": 27.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2335,9 +1947,7 @@
         "dropoff": "Bush Street 672, Rushford, USA",
         "price": 69
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2347,9 +1957,7 @@
         "dropoff": "Dobbin Street 326, Urbana, USA",
         "price": 50.71
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2359,9 +1967,7 @@
         "dropoff": "Malta Street 75, Gratton, USA",
         "price": 18.07
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2371,9 +1977,7 @@
         "dropoff": "Bulwer Place 393, Dawn, USA",
         "price": 23.52
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2383,9 +1987,7 @@
         "dropoff": "Keen Court 578, Coloma, USA",
         "price": 60.4
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2395,9 +1997,7 @@
         "dropoff": "Tiffany Place 78, Loma, USA",
         "price": 15.48
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2407,9 +2007,7 @@
         "dropoff": "Etna Street 26, Waterloo, USA",
         "price": 10.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2419,9 +2017,7 @@
         "dropoff": "India Street 394, Nutrioso, USA",
         "price": 45.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2431,9 +2027,7 @@
         "dropoff": "Hart Place 371, Sardis, USA",
         "price": 90.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2443,9 +2037,7 @@
         "dropoff": "Winthrop Street 94, Nanafalia, USA",
         "price": 92.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2455,9 +2047,7 @@
         "dropoff": "Bowne Street 975, Ferney, USA",
         "price": 30.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2467,9 +2057,7 @@
         "dropoff": "Milton Street 162, Sunriver, USA",
         "price": 89.29
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2479,9 +2067,7 @@
         "dropoff": "Hinckley Place 865, Riviera, USA",
         "price": 29.8
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2491,9 +2077,7 @@
         "dropoff": "Croton Loop 371, Ogema, USA",
         "price": 66.92
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2503,9 +2087,7 @@
         "dropoff": "Holt Court 200, Omar, USA",
         "price": 12.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2515,9 +2097,7 @@
         "dropoff": "Dahill Road 839, Highland, USA",
         "price": 10.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2527,9 +2107,7 @@
         "dropoff": "Ellery Street 252, Maplewood, USA",
         "price": 45.17
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2539,9 +2117,7 @@
         "dropoff": "Seagate Terrace 763, Graniteville, USA",
         "price": 59.14
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2551,9 +2127,7 @@
         "dropoff": "Hanson Place 298, Sims, USA",
         "price": 67.08
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2563,9 +2137,7 @@
         "dropoff": "Crystal Street 587, Gloucester, USA",
         "price": 21.49
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2575,9 +2147,7 @@
         "dropoff": "Clifford Place 627, Zeba, USA",
         "price": 39.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2587,9 +2157,7 @@
         "dropoff": "Schenck Place 734, Whitehaven, USA",
         "price": 32.61
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2599,9 +2167,7 @@
         "dropoff": "Bills Place 34, Juntura, USA",
         "price": 32.39
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2611,9 +2177,7 @@
         "dropoff": "Brigham Street 540, Belfair, USA",
         "price": 62.67
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2623,9 +2187,7 @@
         "dropoff": "Ludlam Place 493, Jacksonburg, USA",
         "price": 53.31
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2635,9 +2197,7 @@
         "dropoff": "Greenwood Avenue 407, Connerton, USA",
         "price": 96.3
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2647,9 +2207,7 @@
         "dropoff": "Frank Court 160, Sperryville, USA",
         "price": 79.23
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2659,9 +2217,7 @@
         "dropoff": "Barbey Street 978, Stewartville, USA",
         "price": 85.7
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2671,9 +2227,7 @@
         "dropoff": "Grand Street 784, Groton, USA",
         "price": 37.62
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2683,9 +2237,7 @@
         "dropoff": "Richmond Street 535, Gracey, USA",
         "price": 22.61
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2695,9 +2247,7 @@
         "dropoff": "Beach Place 988, Vandiver, USA",
         "price": 81.17
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2707,9 +2257,7 @@
         "dropoff": "Kiely Place 783, Thomasville, USA",
         "price": 94.53
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2719,9 +2267,7 @@
         "dropoff": "Lee Avenue 828, Rosewood, USA",
         "price": 57.82
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2731,9 +2277,7 @@
         "dropoff": "Ditmars Street 145, Mulberry, USA",
         "price": 68.32
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2743,9 +2287,7 @@
         "dropoff": "Powers Street 511, Foxworth, USA",
         "price": 18.6
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2755,9 +2297,7 @@
         "dropoff": "Stuyvesant Avenue 835, Talpa, USA",
         "price": 45.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2767,9 +2307,7 @@
         "dropoff": "Frost Street 723, Rockingham, USA",
         "price": 91.31
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2779,9 +2317,7 @@
         "dropoff": "Rockaway Avenue 78, Day, USA",
         "price": 52.1
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2791,9 +2327,7 @@
         "dropoff": "Ridge Boulevard 763, Ellerslie, USA",
         "price": 56.5
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2803,9 +2337,7 @@
         "dropoff": "Dank Court 93, Hasty, USA",
         "price": 71.06
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2815,9 +2347,7 @@
         "dropoff": "Campus Place 783, Tryon, USA",
         "price": 18.69
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2827,9 +2357,7 @@
         "dropoff": "Elm Avenue 527, Southmont, USA",
         "price": 93.13
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2839,9 +2367,7 @@
         "dropoff": "Balfour Place 130, Williams, USA",
         "price": 10.92
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2851,9 +2377,7 @@
         "dropoff": "Fay Court 762, Vicksburg, USA",
         "price": 49.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2863,9 +2387,7 @@
         "dropoff": "Howard Place 960, Chloride, USA",
         "price": 80.5
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2875,9 +2397,7 @@
         "dropoff": "Whitwell Place 296, Otranto, USA",
         "price": 98.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2887,9 +2407,7 @@
         "dropoff": "Brightwater Court 973, Bainbridge, USA",
         "price": 98.63
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2899,9 +2417,7 @@
         "dropoff": "Ryder Avenue 608, Heil, USA",
         "price": 18.4
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2911,9 +2427,7 @@
         "dropoff": "Montgomery Place 135, Indio, USA",
         "price": 75.44
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2923,9 +2437,7 @@
         "dropoff": "Kensington Walk 683, Yorklyn, USA",
         "price": 36.58
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2935,9 +2447,7 @@
         "dropoff": "Bergen Court 748, Sandston, USA",
         "price": 19.91
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2947,9 +2457,7 @@
         "dropoff": "Beayer Place 70, Sunbury, USA",
         "price": 15.52
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2959,9 +2467,7 @@
         "dropoff": "Williams Court 9, Konterra, USA",
         "price": 40.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2971,9 +2477,7 @@
         "dropoff": "Doone Court 625, Wawona, USA",
         "price": 62.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2983,9 +2487,7 @@
         "dropoff": "Hudson Avenue 335, Rivereno, USA",
         "price": 18.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -2995,9 +2497,7 @@
         "dropoff": "Church Lane 70, Longbranch, USA",
         "price": 18.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3007,9 +2507,7 @@
         "dropoff": "Lawrence Avenue 499, Richville, USA",
         "price": 75.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3019,9 +2517,7 @@
         "dropoff": "Bliss Terrace 374, Coalmont, USA",
         "price": 51.52
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3031,9 +2527,7 @@
         "dropoff": "Lexington Avenue 551, Lafferty, USA",
         "price": 58.24
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3043,9 +2537,7 @@
         "dropoff": "Kings Place 62, Neibert, USA",
         "price": 15.49
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3055,9 +2547,7 @@
         "dropoff": "Harbor Lane 226, Brenton, USA",
         "price": 17.41
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3067,9 +2557,7 @@
         "dropoff": "Himrod Street 174, Woodlands, USA",
         "price": 26.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3079,9 +2567,7 @@
         "dropoff": "Wolf Place 589, Bartonsville, USA",
         "price": 75.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3091,9 +2577,7 @@
         "dropoff": "Royce Street 501, Stockdale, USA",
         "price": 32.08
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3103,9 +2587,7 @@
         "dropoff": "Vanderbilt Avenue 220, Hickory, USA",
         "price": 27.67
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3115,9 +2597,7 @@
         "dropoff": "Thomas Street 551, Cutter, USA",
         "price": 28.1
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3127,9 +2607,7 @@
         "dropoff": "Bancroft Place 280, Trail, USA",
         "price": 23.97
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3139,9 +2617,7 @@
         "dropoff": "Polhemus Place 310, Ahwahnee, USA",
         "price": 21.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3151,9 +2627,7 @@
         "dropoff": "Woodbine Street 585, Remington, USA",
         "price": 41.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3163,9 +2637,7 @@
         "dropoff": "River Street 201, Rehrersburg, USA",
         "price": 27.89
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3175,9 +2647,7 @@
         "dropoff": "Thames Street 700, Dorneyville, USA",
         "price": 21.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3187,9 +2657,7 @@
         "dropoff": "Elmwood Avenue 1000, Cavalero, USA",
         "price": 74.82
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3199,9 +2667,7 @@
         "dropoff": "Poplar Avenue 514, Wintersburg, USA",
         "price": 23.24
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3211,9 +2677,7 @@
         "dropoff": "Jamaica Avenue 400, Nescatunga, USA",
         "price": 31.02
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3223,9 +2687,7 @@
         "dropoff": "Glenwood Road 1, Bellfountain, USA",
         "price": 89.27
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3235,9 +2697,7 @@
         "dropoff": "Poly Place 978, Mappsville, USA",
         "price": 44.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3247,9 +2707,7 @@
         "dropoff": "Stryker Street 35, Malo, USA",
         "price": 47.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3259,9 +2717,7 @@
         "dropoff": "Kenmore Terrace 649, Lupton, USA",
         "price": 55.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3271,9 +2727,7 @@
         "dropoff": "Chestnut Avenue 104, Wescosville, USA",
         "price": 70.35
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3283,9 +2737,7 @@
         "dropoff": "Beekman Place 147, Bascom, USA",
         "price": 29.31
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3295,9 +2747,7 @@
         "dropoff": "Sandford Street 335, Maury, USA",
         "price": 10.17
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3307,9 +2757,7 @@
         "dropoff": "Bragg Court 515, Camptown, USA",
         "price": 73.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3319,9 +2767,7 @@
         "dropoff": "Troy Avenue 741, Warren, USA",
         "price": 75.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3331,9 +2777,7 @@
         "dropoff": "Henderson Walk 154, Martell, USA",
         "price": 62.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3343,9 +2787,7 @@
         "dropoff": "Kane Place 159, Eureka, USA",
         "price": 57.01
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3355,9 +2797,7 @@
         "dropoff": "Poplar Street 314, Boomer, USA",
         "price": 55.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3367,9 +2807,7 @@
         "dropoff": "Dennett Place 809, Mapletown, USA",
         "price": 32.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3379,9 +2817,7 @@
         "dropoff": "Heath Place 459, Barronett, USA",
         "price": 34.13
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3391,9 +2827,7 @@
         "dropoff": "Degraw Street 278, Kula, USA",
         "price": 75.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3403,9 +2837,7 @@
         "dropoff": "Schenectady Avenue 522, Bellamy, USA",
         "price": 25.55
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3415,9 +2847,7 @@
         "dropoff": "Newton Street 283, Lopezo, USA",
         "price": 24.5
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3427,9 +2857,7 @@
         "dropoff": "Locust Avenue 824, Campo, USA",
         "price": 90.62
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3439,9 +2867,7 @@
         "dropoff": "Boynton Place 312, Sattley, USA",
         "price": 42.67
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3451,9 +2877,7 @@
         "dropoff": "Taaffe Place 161, Coyote, USA",
         "price": 80.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3463,9 +2887,7 @@
         "dropoff": "Bushwick Avenue 649, Washington, USA",
         "price": 89.01
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3475,9 +2897,7 @@
         "dropoff": "Saratoga Avenue 739, Garnet, USA",
         "price": 47.18
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3487,9 +2907,7 @@
         "dropoff": "Evergreen Avenue 39, Ypsilanti, USA",
         "price": 41.86
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3499,9 +2917,7 @@
         "dropoff": "Story Court 293, Soudan, USA",
         "price": 77.1
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3511,9 +2927,7 @@
         "dropoff": "Jamison Lane 843, Whitmer, USA",
         "price": 92.34
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3523,9 +2937,7 @@
         "dropoff": "McKibbin Street 495, Moscow, USA",
         "price": 57.74
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3535,9 +2947,7 @@
         "dropoff": "Fillmore Avenue 806, Eagleville, USA",
         "price": 53.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3547,9 +2957,7 @@
         "dropoff": "Furman Street 771, Harold, USA",
         "price": 41.86
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3559,9 +2967,7 @@
         "dropoff": "Withers Street 1000, Grayhawk, USA",
         "price": 73.51
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3571,9 +2977,7 @@
         "dropoff": "Lloyd Street 762, Crown, USA",
         "price": 78.97
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3583,9 +2987,7 @@
         "dropoff": "Vermont Street 109, Hiwasse, USA",
         "price": 22.55
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3595,9 +2997,7 @@
         "dropoff": "Hutchinson Court 994, Brecon, USA",
         "price": 82.7
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3607,9 +3007,7 @@
         "dropoff": "Sutton Street 124, Belvoir, USA",
         "price": 67
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3619,9 +3017,7 @@
         "dropoff": "Woodrow Court 124, Linwood, USA",
         "price": 71.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3631,9 +3027,7 @@
         "dropoff": "Stoddard Place 372, Manchester, USA",
         "price": 72.39
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3643,9 +3037,7 @@
         "dropoff": "Columbus Place 581, Finzel, USA",
         "price": 73.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3655,9 +3047,7 @@
         "dropoff": "Norman Avenue 580, Cornfields, USA",
         "price": 68.86
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3667,9 +3057,7 @@
         "dropoff": "Hicks Street 310, Dunlo, USA",
         "price": 47.86
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3679,9 +3067,7 @@
         "dropoff": "Beaver Street 31, Cucumber, USA",
         "price": 74.37
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3691,9 +3077,7 @@
         "dropoff": "Fleet Street 119, Fostoria, USA",
         "price": 77.6
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3703,9 +3087,7 @@
         "dropoff": "Milford Street 930, Kaka, USA",
         "price": 47.89
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3715,9 +3097,7 @@
         "dropoff": "Jackson Court 787, Evergreen, USA",
         "price": 35.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3727,9 +3107,7 @@
         "dropoff": "Fillmore Place 838, Garfield, USA",
         "price": 29.02
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3739,9 +3117,7 @@
         "dropoff": "Canarsie Road 163, Cherokee, USA",
         "price": 22.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3751,9 +3127,7 @@
         "dropoff": "Laurel Avenue 881, Summerfield, USA",
         "price": 45.7
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3763,9 +3137,7 @@
         "dropoff": "Knickerbocker Avenue 390, Blodgett, USA",
         "price": 29.44
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3775,9 +3147,7 @@
         "dropoff": "Dorchester Road 521, Tyhee, USA",
         "price": 74.3
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3787,9 +3157,7 @@
         "dropoff": "Newkirk Avenue 196, Marysville, USA",
         "price": 15.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3799,9 +3167,7 @@
         "dropoff": "Pioneer Street 930, Glenbrook, USA",
         "price": 62.93
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3811,9 +3177,7 @@
         "dropoff": "Llama Court 587, Balm, USA",
         "price": 31.13
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3823,9 +3187,7 @@
         "dropoff": "Roder Avenue 232, Clara, USA",
         "price": 31.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3835,9 +3197,7 @@
         "dropoff": "Seagate Avenue 184, Frank, USA",
         "price": 66.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3847,9 +3207,7 @@
         "dropoff": "Guider Avenue 957, Cassel, USA",
         "price": 97.55
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3859,9 +3217,7 @@
         "dropoff": "Varick Avenue 230, Chestnut, USA",
         "price": 33.42
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3871,9 +3227,7 @@
         "dropoff": "Howard Alley 662, Brantleyville, USA",
         "price": 81.24
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3883,9 +3237,7 @@
         "dropoff": "Wilson Avenue 597, Hollins, USA",
         "price": 47.43
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3895,9 +3247,7 @@
         "dropoff": "Ralph Avenue 741, Trexlertown, USA",
         "price": 37.75
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3907,9 +3257,7 @@
         "dropoff": "Nevins Street 323, Dunnavant, USA",
         "price": 24.63
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3919,9 +3267,7 @@
         "dropoff": "Kathleen Court 693, Harborton, USA",
         "price": 45.77
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3931,9 +3277,7 @@
         "dropoff": "Cumberland Walk 375, Wright, USA",
         "price": 81.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3943,9 +3287,7 @@
         "dropoff": "Miami Court 759, Chical, USA",
         "price": 75.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3955,9 +3297,7 @@
         "dropoff": "Nolans Lane 684, Stewart, USA",
         "price": 87.26
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3967,9 +3307,7 @@
         "dropoff": "Highland Avenue 130, Longoria, USA",
         "price": 88.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3979,9 +3317,7 @@
         "dropoff": "Everit Street 441, Chesterfield, USA",
         "price": 91.28
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -3991,9 +3327,7 @@
         "dropoff": "Clinton Street 257, Navarre, USA",
         "price": 87.58
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4003,9 +3337,7 @@
         "dropoff": "Midwood Street 70, Grenelefe, USA",
         "price": 68.48
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4015,9 +3347,7 @@
         "dropoff": "Highland Place 357, Haena, USA",
         "price": 91.06
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4027,9 +3357,7 @@
         "dropoff": "Batchelder Street 609, Romeville, USA",
         "price": 15.72
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4039,9 +3367,7 @@
         "dropoff": "Just Court 810, Woodruff, USA",
         "price": 69.78
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4051,9 +3377,7 @@
         "dropoff": "Jerome Street 45, Russellville, USA",
         "price": 14.06
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4063,9 +3387,7 @@
         "dropoff": "Hampton Place 221, Coaldale, USA",
         "price": 92.27
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4075,9 +3397,7 @@
         "dropoff": "Irving Street 520, Winston, USA",
         "price": 98.3
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4087,9 +3407,7 @@
         "dropoff": "Montieth Street 56, Abrams, USA",
         "price": 21.35
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4099,9 +3417,7 @@
         "dropoff": "Brightwater Avenue 330, Freelandville, USA",
         "price": 57.34
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4111,9 +3427,7 @@
         "dropoff": "Dodworth Street 683, Gerton, USA",
         "price": 10.43
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4123,9 +3437,7 @@
         "dropoff": "Stillwell Place 485, Orick, USA",
         "price": 49.55
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4135,9 +3447,7 @@
         "dropoff": "Willoughby Avenue 397, Stockwell, USA",
         "price": 67.41
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4147,9 +3457,7 @@
         "dropoff": "Wythe Place 381, Greenfields, USA",
         "price": 76.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4159,9 +3467,7 @@
         "dropoff": "Halleck Street 357, Websterville, USA",
         "price": 40.73
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4171,9 +3477,7 @@
         "dropoff": "Havemeyer Street 367, Southview, USA",
         "price": 42.63
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4183,9 +3487,7 @@
         "dropoff": "Norfolk Street 321, Oasis, USA",
         "price": 39.36
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4195,9 +3497,7 @@
         "dropoff": "Driggs Avenue 898, Aberdeen, USA",
         "price": 66.75
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4207,9 +3507,7 @@
         "dropoff": "Vanderveer Place 968, Bradenville, USA",
         "price": 19.23
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4219,9 +3517,7 @@
         "dropoff": "Navy Street 433, Escondida, USA",
         "price": 96.6
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4231,9 +3527,7 @@
         "dropoff": "Cleveland Street 687, Wauhillau, USA",
         "price": 70.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4243,9 +3537,7 @@
         "dropoff": "Bartlett Place 566, Matheny, USA",
         "price": 23.77
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4255,9 +3547,7 @@
         "dropoff": "Alabama Avenue 377, Ona, USA",
         "price": 90.77
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4267,9 +3557,7 @@
         "dropoff": "Oakland Place 858, Tibbie, USA",
         "price": 36.47
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4279,9 +3567,7 @@
         "dropoff": "Interborough Parkway 167, Osmond, USA",
         "price": 64.68
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4291,9 +3577,7 @@
         "dropoff": "Corbin Place 105, Baden, USA",
         "price": 13.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4303,9 +3587,7 @@
         "dropoff": "Butler Street 736, Walland, USA",
         "price": 96.79
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4315,9 +3597,7 @@
         "dropoff": "Celeste Court 812, Hamilton, USA",
         "price": 21.48
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4327,9 +3607,7 @@
         "dropoff": "Beard Street 613, Layhill, USA",
         "price": 64.57
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4339,9 +3617,7 @@
         "dropoff": "Rodney Street 553, Fairacres, USA",
         "price": 76.67
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4351,9 +3627,7 @@
         "dropoff": "Rost Place 887, Wyano, USA",
         "price": 54.52
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4363,9 +3637,7 @@
         "dropoff": "Buffalo Avenue 418, Glasgow, USA",
         "price": 55.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4375,9 +3647,7 @@
         "dropoff": "George Street 85, Whipholt, USA",
         "price": 85.85
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4387,9 +3657,7 @@
         "dropoff": "Baughman Place 410, Babb, USA",
         "price": 62.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4399,9 +3667,7 @@
         "dropoff": "Harrison Place 873, Gorst, USA",
         "price": 44.15
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4411,9 +3677,7 @@
         "dropoff": "Lewis Avenue 670, Tilleda, USA",
         "price": 17.7
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4423,9 +3687,7 @@
         "dropoff": "Thatford Avenue 394, Clarksburg, USA",
         "price": 57.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4435,9 +3697,7 @@
         "dropoff": "Schenck Avenue 194, Freeburn, USA",
         "price": 66.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4447,9 +3707,7 @@
         "dropoff": "Coffey Street 853, Falmouth, USA",
         "price": 74.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4459,9 +3717,7 @@
         "dropoff": "Chester Street 912, Bladensburg, USA",
         "price": 48.69
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4471,9 +3727,7 @@
         "dropoff": "Wolcott Street 54, Caroleen, USA",
         "price": 87.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4483,9 +3737,7 @@
         "dropoff": "Porter Avenue 680, Defiance, USA",
         "price": 52.79
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4495,9 +3747,7 @@
         "dropoff": "Montauk Court 591, Crumpler, USA",
         "price": 36.13
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4507,9 +3757,7 @@
         "dropoff": "Paerdegat Avenue 571, Sugartown, USA",
         "price": 53.14
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4519,9 +3767,7 @@
         "dropoff": "Lincoln Place 202, Fedora, USA",
         "price": 66.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4531,9 +3777,7 @@
         "dropoff": "Bedford Place 89, Felt, USA",
         "price": 94.91
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4543,9 +3787,7 @@
         "dropoff": "Manhattan Avenue 206, Worton, USA",
         "price": 40.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4555,9 +3797,7 @@
         "dropoff": "Essex Street 216, Dixonville, USA",
         "price": 36.3
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4567,9 +3807,7 @@
         "dropoff": "Livonia Avenue 615, Rosedale, USA",
         "price": 40.59
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4579,9 +3817,7 @@
         "dropoff": "Stewart Street 352, Cotopaxi, USA",
         "price": 24.16
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4591,9 +3827,7 @@
         "dropoff": "Tudor Terrace 424, Glenshaw, USA",
         "price": 36.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4603,9 +3837,7 @@
         "dropoff": "Butler Place 186, Venice, USA",
         "price": 60.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4615,9 +3847,7 @@
         "dropoff": "Stockton Street 352, Coventry, USA",
         "price": 17.37
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4627,9 +3857,7 @@
         "dropoff": "Ross Street 79, Neahkahnie, USA",
         "price": 13.79
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4639,9 +3867,7 @@
         "dropoff": "Vandervoort Avenue 405, Fairfield, USA",
         "price": 45.44
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4651,9 +3877,7 @@
         "dropoff": "Tampa Court 249, Duryea, USA",
         "price": 50.96
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4663,9 +3887,7 @@
         "dropoff": "Vine Street 513, Manila, USA",
         "price": 52.93
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4675,9 +3897,7 @@
         "dropoff": "Grant Avenue 278, Eastmont, USA",
         "price": 42.95
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4687,9 +3907,7 @@
         "dropoff": "Amersfort Place 102, Leroy, USA",
         "price": 68.81
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4699,9 +3917,7 @@
         "dropoff": "Grimes Road 466, Riegelwood, USA",
         "price": 46.83
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4711,9 +3927,7 @@
         "dropoff": "Matthews Court 410, Harleigh, USA",
         "price": 44.89
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4723,9 +3937,7 @@
         "dropoff": "Imlay Street 542, Woodlake, USA",
         "price": 99.99
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4735,9 +3947,7 @@
         "dropoff": "Knight Court 337, Davenport, USA",
         "price": 26.17
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4747,9 +3957,7 @@
         "dropoff": "Adams Street 577, Tilden, USA",
         "price": 56.77
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4759,9 +3967,7 @@
         "dropoff": "Cheever Place 18, Columbus, USA",
         "price": 46.08
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4771,9 +3977,7 @@
         "dropoff": "Eagle Street 241, Trinway, USA",
         "price": 74.69
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4783,9 +3987,7 @@
         "dropoff": "Coyle Street 355, Lydia, USA",
         "price": 97.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4795,9 +3997,7 @@
         "dropoff": "Mill Lane 741, Biehle, USA",
         "price": 92.53
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4807,9 +4007,7 @@
         "dropoff": "Terrace Place 711, Clarktown, USA",
         "price": 94.47
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4819,9 +4017,7 @@
         "dropoff": "Riverdale Avenue 862, Garberville, USA",
         "price": 28.86
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4831,9 +4027,7 @@
         "dropoff": "Pooles Lane 729, Gouglersville, USA",
         "price": 12.99
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4843,9 +4037,7 @@
         "dropoff": "Oliver Street 478, Ribera, USA",
         "price": 32.77
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4855,9 +4047,7 @@
         "dropoff": "Johnson Avenue 405, Hardyville, USA",
         "price": 63.17
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4867,9 +4057,7 @@
         "dropoff": "Hegeman Avenue 265, Slovan, USA",
         "price": 11.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4879,9 +4067,7 @@
         "dropoff": "Clara Street 592, Chaparrito, USA",
         "price": 83.71
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4891,9 +4077,7 @@
         "dropoff": "Berkeley Place 696, Titanic, USA",
         "price": 83.8
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4903,9 +4087,7 @@
         "dropoff": "Oriental Boulevard 185, Sterling, USA",
         "price": 48.08
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4915,9 +4097,7 @@
         "dropoff": "Creamer Street 954, Belgreen, USA",
         "price": 29.68
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4927,9 +4107,7 @@
         "dropoff": "Tillary Street 228, Roy, USA",
         "price": 90.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4939,9 +4117,7 @@
         "dropoff": "Waldane Court 912, Bannock, USA",
         "price": 68.18
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4951,9 +4127,7 @@
         "dropoff": "Greenpoint Avenue 268, Nipinnawasee, USA",
         "price": 86.49
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4963,9 +4137,7 @@
         "dropoff": "Taylor Street 67, Cresaptown, USA",
         "price": 95.02
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4975,9 +4147,7 @@
         "dropoff": "Hancock Street 601, Bluffview, USA",
         "price": 96.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4987,9 +4157,7 @@
         "dropoff": "Macdougal Street 785, Datil, USA",
         "price": 82.29
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -4999,9 +4167,7 @@
         "dropoff": "Luquer Street 929, Utting, USA",
         "price": 87.22
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5011,9 +4177,7 @@
         "dropoff": "Clermont Avenue 515, Mooresburg, USA",
         "price": 64.07
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5023,9 +4187,7 @@
         "dropoff": "Crescent Street 255, Henrietta, USA",
         "price": 90.72
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5035,9 +4197,7 @@
         "dropoff": "Prince Street 767, Dola, USA",
         "price": 70.83
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5047,9 +4207,7 @@
         "dropoff": "Neptune Court 137, Fruitdale, USA",
         "price": 23.54
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5059,9 +4217,7 @@
         "dropoff": "Jay Street 108, Logan, USA",
         "price": 66.41
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5071,9 +4227,7 @@
         "dropoff": "Atkins Avenue 261, Hendersonville, USA",
         "price": 20.55
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5083,9 +4237,7 @@
         "dropoff": "Turner Place 129, Wacissa, USA",
         "price": 32.75
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5095,9 +4247,7 @@
         "dropoff": "Throop Avenue 467, Darbydale, USA",
         "price": 36.35
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5107,9 +4257,7 @@
         "dropoff": "Oak Street 771, Makena, USA",
         "price": 68.76
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5119,9 +4267,7 @@
         "dropoff": "Friel Place 125, Martinsville, USA",
         "price": 93.71
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5131,9 +4277,7 @@
         "dropoff": "Bath Avenue 747, Falconaire, USA",
         "price": 42.58
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5143,9 +4287,7 @@
         "dropoff": "Menahan Street 314, Camas, USA",
         "price": 71.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5155,9 +4297,7 @@
         "dropoff": "Indiana Place 722, Cressey, USA",
         "price": 25.14
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5167,9 +4307,7 @@
         "dropoff": "Harden Street 770, Westwood, USA",
         "price": 54.66
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5179,9 +4317,7 @@
         "dropoff": "Court Street 943, Caledonia, USA",
         "price": 54.74
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5191,9 +4327,7 @@
         "dropoff": "Brighton Court 711, Holtville, USA",
         "price": 86.42
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5203,9 +4337,7 @@
         "dropoff": "Montana Place 617, Chamberino, USA",
         "price": 37.21
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5215,9 +4347,7 @@
         "dropoff": "Turnbull Avenue 245, Townsend, USA",
         "price": 94.78
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5227,9 +4357,7 @@
         "dropoff": "Strickland Avenue 489, Watrous, USA",
         "price": 95.83
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5239,9 +4367,7 @@
         "dropoff": "Herzl Street 763, Kraemer, USA",
         "price": 46.34
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5251,9 +4377,7 @@
         "dropoff": "Shale Street 4, Austinburg, USA",
         "price": 26.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5263,9 +4387,7 @@
         "dropoff": "Royce Place 435, Faxon, USA",
         "price": 33.26
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5275,9 +4397,7 @@
         "dropoff": "Rutherford Place 594, Fairhaven, USA",
         "price": 29.41
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5287,9 +4407,7 @@
         "dropoff": "Baycliff Terrace 447, Bartley, USA",
         "price": 13.91
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5299,9 +4417,7 @@
         "dropoff": "Clove Road 591, Zortman, USA",
         "price": 74.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5311,9 +4427,7 @@
         "dropoff": "Malbone Street 645, Blanco, USA",
         "price": 35.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5323,9 +4437,7 @@
         "dropoff": "Stuart Street 718, Dexter, USA",
         "price": 69.65
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5335,9 +4447,7 @@
         "dropoff": "Reeve Place 349, Gulf, USA",
         "price": 19.77
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5347,9 +4457,7 @@
         "dropoff": "Jaffray Street 286, Holcombe, USA",
         "price": 23.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5359,9 +4467,7 @@
         "dropoff": "Linwood Street 301, Chamizal, USA",
         "price": 25.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5371,9 +4477,7 @@
         "dropoff": "Brooklyn Avenue 241, Hoagland, USA",
         "price": 17.14
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5383,9 +4487,7 @@
         "dropoff": "Lawton Street 584, Alfarata, USA",
         "price": 58.69
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5395,9 +4497,7 @@
         "dropoff": "Ocean Avenue 645, Windsor, USA",
         "price": 30.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5407,9 +4507,7 @@
         "dropoff": "Monument Walk 270, Outlook, USA",
         "price": 23.91
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5419,9 +4517,7 @@
         "dropoff": "Kent Avenue 16, Topaz, USA",
         "price": 91.99
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5431,9 +4527,7 @@
         "dropoff": "Townsend Street 264, Ripley, USA",
         "price": 85.05
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5443,9 +4537,7 @@
         "dropoff": "Tapscott Street 999, Shasta, USA",
         "price": 61.76
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5455,9 +4547,7 @@
         "dropoff": "Stone Avenue 323, Jeff, USA",
         "price": 50.74
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5467,9 +4557,7 @@
         "dropoff": "Hornell Loop 211, Hessville, USA",
         "price": 56.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5479,9 +4567,7 @@
         "dropoff": "Fane Court 584, Springdale, USA",
         "price": 73.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5491,9 +4577,7 @@
         "dropoff": "Preston Court 133, Laurelton, USA",
         "price": 87.32
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5503,9 +4587,7 @@
         "dropoff": "Classon Avenue 767, Coldiron, USA",
         "price": 86.72
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5515,9 +4597,7 @@
         "dropoff": "Columbia Place 264, Belleview, USA",
         "price": 18.4
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5527,9 +4607,7 @@
         "dropoff": "Willow Place 333, Independence, USA",
         "price": 14.25
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5539,9 +4617,7 @@
         "dropoff": "Rugby Road 708, Condon, USA",
         "price": 68.72
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5551,9 +4627,7 @@
         "dropoff": "Radde Place 15, Hannasville, USA",
         "price": 70.44
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5563,9 +4637,7 @@
         "dropoff": "Seaview Avenue 265, Morningside, USA",
         "price": 15.96
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5575,9 +4647,7 @@
         "dropoff": "Lenox Road 523, Ronco, USA",
         "price": 63.38
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5587,9 +4657,7 @@
         "dropoff": "Johnson Street 42, Kidder, USA",
         "price": 10.38
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5599,9 +4667,7 @@
         "dropoff": "Wyckoff Avenue 985, Strong, USA",
         "price": 11.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5611,9 +4677,7 @@
         "dropoff": "Brevoort Place 394, Elliston, USA",
         "price": 84.27
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5623,9 +4687,7 @@
         "dropoff": "Victor Road 841, Efland, USA",
         "price": 17.44
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5635,9 +4697,7 @@
         "dropoff": "Ashford Street 836, Adamstown, USA",
         "price": 47.38
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5647,9 +4707,7 @@
         "dropoff": "Montague Terrace 824, Fresno, USA",
         "price": 85.97
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5659,9 +4717,7 @@
         "dropoff": "Tilden Avenue 616, Rew, USA",
         "price": 60.11
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5671,9 +4727,7 @@
         "dropoff": "Willmohr Street 337, Maybell, USA",
         "price": 56.8
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5683,9 +4737,7 @@
         "dropoff": "Overbaugh Place 779, Needmore, USA",
         "price": 72.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5695,9 +4747,7 @@
         "dropoff": "Loring Avenue 992, Berlin, USA",
         "price": 13.43
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5707,9 +4757,7 @@
         "dropoff": "Linden Boulevard 82, Devon, USA",
         "price": 44
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5719,9 +4767,7 @@
         "dropoff": "Ryerson Street 432, Summerset, USA",
         "price": 50.33
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5731,9 +4777,7 @@
         "dropoff": "Ivan Court 338, Elrama, USA",
         "price": 54.39
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5743,9 +4787,7 @@
         "dropoff": "Cobek Court 327, Levant, USA",
         "price": 65.94
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5755,9 +4797,7 @@
         "dropoff": "Bevy Court 194, Bethpage, USA",
         "price": 69.04
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5767,9 +4807,7 @@
         "dropoff": "Nassau Avenue 740, Stonybrook, USA",
         "price": 90.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5779,9 +4817,7 @@
         "dropoff": "Marconi Place 262, Caroline, USA",
         "price": 64.08
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5791,9 +4827,7 @@
         "dropoff": "Hawthorne Street 260, Lloyd, USA",
         "price": 73.79
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5803,9 +4837,7 @@
         "dropoff": "Dahlgreen Place 519, Shaft, USA",
         "price": 21.82
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5815,9 +4847,7 @@
         "dropoff": "Devoe Street 774, Dupuyer, USA",
         "price": 74.69
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5827,9 +4857,7 @@
         "dropoff": "Brighton Avenue 977, Hackneyville, USA",
         "price": 59.04
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5839,9 +4867,7 @@
         "dropoff": "Estate Road 55, Homestead, USA",
         "price": 35.88
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5851,9 +4877,7 @@
         "dropoff": "Cranberry Street 565, Emory, USA",
         "price": 34.93
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5863,9 +4887,7 @@
         "dropoff": "Bleecker Street 184, Wedgewood, USA",
         "price": 67.18
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5875,9 +4897,7 @@
         "dropoff": "Maujer Street 153, Vernon, USA",
         "price": 30.49
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5887,9 +4907,7 @@
         "dropoff": "Lawn Court 66, Linganore, USA",
         "price": 32.37
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5899,9 +4917,7 @@
         "dropoff": "Montauk Avenue 74, Blandburg, USA",
         "price": 99.09
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5911,9 +4927,7 @@
         "dropoff": "Bainbridge Street 762, Westphalia, USA",
         "price": 84.67
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5923,9 +4937,7 @@
         "dropoff": "Cox Place 547, Cannondale, USA",
         "price": 23.75
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5935,9 +4947,7 @@
         "dropoff": "Landis Court 83, Cade, USA",
         "price": 93.64
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5947,9 +4957,7 @@
         "dropoff": "Russell Street 402, Dahlen, USA",
         "price": 29.8
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5959,9 +4967,7 @@
         "dropoff": "Louise Terrace 101, Winchester, USA",
         "price": 17.12
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5971,9 +4977,7 @@
         "dropoff": "Krier Place 303, Williston, USA",
         "price": 80.19
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5983,9 +4987,7 @@
         "dropoff": "Bennet Court 132, Manitou, USA",
         "price": 82.91
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     },
     {
       "log_level": "info",
@@ -5995,8 +4997,6 @@
         "dropoff": "Thornton Street 50, Harrodsburg, USA",
         "price": 81.2
       },
-      "message": {
-        "event": "RideCreated"
-      }
+      "message": "{\"event\":\"RideCreated\"}"
     }
   ]


### PR DESCRIPTION
We observed that in absence of any ingestion pipeline, Datadog flattens the message field in JSON log items and the children fields that are in there end up overwriting equally named fields already present at the top level of the JSON object.
In an attempt at reproducing this issue and getting support on this from Datadog, this PR updates the fake success log messages to include such message field. Also it moves the existing `event` field inside the `message` fields, and adds a new `event` field, with an overall result that more closely resembles what is used in Kiev.
In roughly half of the cases, the `message` field is stringified, in order to have something similar to what we have in some production services, like `market-manager`.